### PR TITLE
Litecoin repeated dup blocks disconnect

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -170,6 +170,7 @@ public:
     std::string addrName;
     CService addrLocal;
     int nVersion;
+    int nDupBlocks;
     std::string strSubVer;
     bool fOneShot;
     bool fClient;
@@ -221,6 +222,7 @@ public:
         addr = addrIn;
         addrName = addrNameIn == "" ? addr.ToStringIPPort() : addrNameIn;
         nVersion = 0;
+        nDupBlocks = 0;
         strSubVer = "";
         fOneShot = false;
         fClient = false; // set by version message


### PR DESCRIPTION
Fixes the problem with frequent block downloads that have already been downloaded and therefore saves on bandwidth for both nodes.
