### PR TITLE
Update build dependencies for current Debian (wheezy) and Ubuntu (raring)

### DIFF
--- a/doc/readme-qt.rst
+++ b/doc/readme-qt.rst
@@ -14,7 +14,7 @@ distribution are installed, for Debian and Ubuntu these are:
 
     apt-get install qt4-qmake libqt4-dev build-essential libboost-dev libboost-system-dev \
         libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev \
-        libssl-dev libdb4.8++-dev
+        libssl-dev libdb++-dev libminiupnpc-dev
 
 then execute the following:
 


### PR DESCRIPTION
Update build dependencies for current Debian (wheezy) and Ubuntu (raring)

doc/readme-qt.txt's "apt-get install..." fails saying:
E: Package 'libdb4.8++-dev' has no installation candidate
but libdb++-dev exists and installs the latest version (5.1)

Building then fails saying:
src/net.cpp:20:32: fatal error: miniupnpc/miniwget.h: No such file or directory
compilation terminated.
for which the is to add libminiupnpc-dev
