### PR TITLE
Updated bitcoin_nb.ts changing "S&amp;avslutt" to "S&amp;end"

### DIFF
--- a/src/qt/locale/bitcoin_nb.ts
+++ b/src/qt/locale/bitcoin_nb.ts
@@ -1331,7 +1331,7 @@ Adresse: %4
     <message>
         <location line="+3"/>
         <source>S&amp;end</source>
-        <translation>S&amp;avslutt</translation>
+        <translation>S&amp;end</translation>
     </message>
     <message>
         <location filename="../sendcoinsdialog.cpp" line="-59"/>


### PR DESCRIPTION
Seems that the translater has problems with words splitt with the '$amp;' key.
