### PR TITLE
log start and end of Shutdown()

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -89,6 +89,7 @@ static CCoinsViewDB *pcoinsdbview;
 
 void Shutdown()
 {
+    LogPrintf("Shutdown : In progress...\n");
     static CCriticalSection cs_Shutdown;
     TRY_LOCK(cs_Shutdown, lockShutdown);
     if (!lockShutdown) return;
@@ -114,6 +115,7 @@ void Shutdown()
     boost::filesystem::remove(GetPidFile());
     UnregisterWallet(pwalletMain);
     delete pwalletMain;
+    LogPrintf("Shutdown : done\n");
 }
 
 //


### PR DESCRIPTION
- could be helpful when debugging shutdown related problems

Rebased-by:   Warren Togami wtogami@gmail.com
Rebased-from: ced3c248168941fbbd42d5a3807657a88be6a54e

https://github.com/bitcoin/bitcoin/pull/3038
Based on this bitcoin master commit.

The MacOS X corruption is suspected to be shutdown related.  We also currently experience a non-fatal shutdown error on Linux with boost-1.53.  So there are multiple reasons why this could be useful to debug.
