### PR TITLE
Update makefile.osx to prevetn some compiling errors under osx 10.9

### DIFF
--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -67,6 +67,9 @@ else
 DEBUGFLAGS = -g
 endif
 
+# osx 10.9 has changed the stdlib default to libc++. To prevent some link error, you may need to use libstdc++
+CFLAGS += -stdlib=libstdc++
+
 # ppc doesn't work because we don't support big-endian
 CFLAGS += -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter \
     $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)


### PR DESCRIPTION
osx 10.9 changed the default stdlib to libc++. You may need to compile with libstdc++ to prevent some errors. At the same time, boost should be compiled use a cxxflag '-stdlib=libstdc++'
