### PR TITLE
Add: requirement libminiupnpc-dev for Debian, in readme-qt

### DIFF
--- a/doc/readme-qt.rst
+++ b/doc/readme-qt.rst
@@ -18,7 +18,7 @@ for Debian and Ubuntu  <= 11.10 :
 
     apt-get install qt4-qmake libqt4-dev build-essential libboost-dev libboost-system-dev \
         libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev \
-        libssl-dev libdb4.8++-dev
+        libssl-dev libdb4.8++-dev libminiupnpc-dev
 
 for Ubuntu >= 12.04 (please read the 'Berkely DB version warning' below):
 


### PR DESCRIPTION
This library is needed on Debian and Ubuntu, unless the flag
to omit UPnP support is set.
