### PR TITLE
Fix .gitignore to properly include leveldb Makefile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ qrc_*.cpp
 .DS_Store
 build
 
-!src/leveldb-*/Makefile
+!src/leveldb*/Makefile


### PR DESCRIPTION
When rebuilding git from scratch, leveldb Makefile is not properly included. The dash should not be there. Fixed in Bitcoin recently as well:

https://github.com/bitcoin/bitcoin/commit/15570cc9aa94b53e95fa847a66e03326c6875d3c
