### PR TITLE
Correct reference to Bitcoin in French locale

### DIFF
--- a/src/qt/locale/bitcoin_fr.ts
+++ b/src/qt/locale/bitcoin_fr.ts
@@ -138,7 +138,7 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Send &amp;Coins</source>
-        <translation>Envoyer des Bit&amp;coins</translation>
+        <translation>Envoyer des &amp;Litecoins</translation>
     </message>
     <message>
         <location line="+260"/>


### PR DESCRIPTION
The French locale file had a reference to Bitcoin, as well as a broken shortcut key (it used 'c', which was already used for another menu option), within the Address tab.

This patch corrects both.
