### PR TITLE
gitian: upgrade to openssl-1.0.1h for CVE-2014-0224

### DIFF
--- a/contrib/gitian-descriptors/deps-win32.yml
+++ b/contrib/gitian-descriptors/deps-win32.yml
@@ -14,7 +14,7 @@ packages:
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "openssl-1.0.1g.tar.gz"
+- "openssl-1.0.1h.tar.gz"
 - "db-4.8.30.NC.tar.gz"
 - "miniupnpc-1.9.20140401.tar.gz"
 - "zlib-1.2.8.tar.gz"
@@ -28,7 +28,7 @@ script: |
   export INSTALLPREFIX=$OUTDIR/staging/deps
   export HOST=i686-w64-mingw32
   # Integrity Check
-  echo "53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028  openssl-1.0.1g.tar.gz"  | sha256sum -c
+  echo "9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093  openssl-1.0.1h.tar.gz"  | sha256sum -c
   echo "12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz"    | sha256sum -c
   echo "d02670112125300f7a3d61421714d99105edd90190bf12542d16785f16f017aa  miniupnpc-1.9.20140401.tar.gz"   | sha256sum -c
   echo "36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d  zlib-1.2.8.tar.gz"      | sha256sum -c
@@ -38,8 +38,8 @@ script: |
   #
   mkdir -p $INSTALLPREFIX
 
-  tar xzf openssl-1.0.1g.tar.gz
-  cd openssl-1.0.1g
+  tar xzf openssl-1.0.1h.tar.gz
+  cd openssl-1.0.1h
   ./Configure --cross-compile-prefix=$HOST- mingw --openssldir=$INSTALLPREFIX
   make
   make install_sw
@@ -98,4 +98,4 @@ script: |
   cd ..
   #
   cd $INSTALLPREFIX
-  zip -r $OUTDIR/bitcoin08-deps-win32-gitian-r10.zip include lib
+  zip -r $OUTDIR/bitcoin08-deps-win32-gitian-r11.zip include lib

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -16,9 +16,9 @@ remotes:
 - "url": "https://github.com/litecoin-project/litecoin.git"
   "dir": "litecoin"
 files:
-- "qt-win32-4.8.5-gitian-r5.zip"
+- "qt-win32-4.8.5-gitian-r6.zip"
 - "boost-win32-1.55.0-gitian-r6.zip"
-- "bitcoin08-deps-win32-gitian-r10.zip"
+- "bitcoin08-deps-win32-gitian-r11.zip"
 script: |
   #
   STAGING=$HOME/staging
@@ -26,9 +26,9 @@ script: |
   #
   mkdir -p $STAGING
   cd $STAGING
-  unzip ../build/qt-win32-4.8.5-gitian-r5.zip
+  unzip ../build/qt-win32-4.8.5-gitian-r6.zip
   unzip ../build/boost-win32-1.55.0-gitian-r6.zip
-  unzip ../build/bitcoin08-deps-win32-gitian-r10.zip
+  unzip ../build/bitcoin08-deps-win32-gitian-r11.zip
   cd $HOME/build/
   #
   cd litecoin

--- a/contrib/gitian-descriptors/qt-win32.yml
+++ b/contrib/gitian-descriptors/qt-win32.yml
@@ -14,7 +14,7 @@ reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
 - "qt-everywhere-opensource-src-4.8.5.tar.gz"
-- "bitcoin08-deps-win32-gitian-r10.zip"
+- "bitcoin08-deps-win32-gitian-r11.zip"
 script: |
   #
   HOST=i686-w64-mingw32
@@ -26,7 +26,7 @@ script: |
   mkdir -p $INSTDIR/host/bin
   #
   # Need mingw-compiled openssl from bitcoin-deps:
-  unzip bitcoin08-deps-win32-gitian-r10.zip
+  unzip bitcoin08-deps-win32-gitian-r11.zip
   DEPSDIR=`pwd`
   #
   tar xzf qt-everywhere-opensource-src-4.8.5.tar.gz
@@ -61,4 +61,4 @@ script: |
 
   # as zip stores file timestamps, use faketime to intercept stat calls to set dates for all files to reference date
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
-  zip -r $OUTDIR/qt-win32-4.8.5-gitian-r5.zip *
+  zip -r $OUTDIR/qt-win32-4.8.5-gitian-r6.zip *

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,3 +1,5 @@
+- Upgrade to openssl-1.0.1h for CVE-2014-0224
+
 0.8.7.1 changes
 =============
 - Mac and Windows Official Gitian Builds: upgrade to openssl-1.0.1g for CVE-2014-0160

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -34,7 +34,7 @@ Release Process
 
 	mkdir -p inputs; cd inputs/
 	wget 'http://miniupnp.free.fr/files/download.php?file=miniupnpc-1.9.20140401.tar.gz' -O miniupnpc-1.9.20140401.tar.gz'
-	wget 'http://www.openssl.org/source/openssl-1.0.1g.tar.gz'
+	wget 'http://www.openssl.org/source/openssl-1.0.1h.tar.gz'
 	wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
 	wget 'http://zlib.net/zlib-1.2.8.tar.gz'
 	wget 'ftp://ftp.simplesystems.org/pub/libpng/png/src/history/libpng16/libpng-1.6.8.tar.gz'


### PR DESCRIPTION
This updates the gitian build files to use OpenSSL version 1.0.1h because of CVE-2014-0224 (https://www.openssl.org/news/secadv_20140605.txt).

I also updated the revision number of the `qt-win32` package as it has a dependency on the `bitcoin08-deps-win32` package which contains the OpenSSL build. I'm not sure whether this is the right way to do it, though.
