### PR TITLE
Rename QVBoxLayout to avoid compilation warning

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -172,7 +172,7 @@
       <attribute name="title">
        <string>&amp;Network</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_Network">
+      <layout class="QVBoxLayout" name="verticalLayout_Network2">
        <item>
         <widget class="QCheckBox" name="mapPortUpnp">
          <property name="toolTip">


### PR DESCRIPTION
There are two QVBoxLayout elements with the name verticalLayout_Network. I have simply named the second one to verticalLayout_Network2 to avoid the warning generated when compiling.
