### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ lots of money.
 
 Large changes should have a test plan, and should be tested by somebody other
 than the developer who wrote the code.
-See https://github.com/bitcoin/QA/ for how to create a test plan.
+See the litecion discussion forum for informaion on how to create a test plan.
+https://litecointalk.org/index.php?PHPSESSID=cetipe60buk34g5pmcm825i8l7&board=2.0
 
 Translations
 ------------


### PR DESCRIPTION
Since litecoin is a separate project from bitcoin should it not have it's own place for discussion of testing plans ?  Since none exists at this time and the project is separate from bitcion I pointed the link to the LitecoinTalk.org »
Litecoin »
Litecoin Development & Technical Discussion  since this seemed the most logical place to make such a proposal as none exists on github. At the very least if ths pull request is not merged I suggest that alternate instructions are provided vs. a link to the bitcoin q/a.

Litecoin obviously has many similar things to bitcoin but certainly is a large enough project to have it's very own areas for this !!