### PR TITLE
changing default confirm target for fee estimation to 2

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -27,7 +27,7 @@ using namespace std;
  */
 CFeeRate payTxFee(DEFAULT_TRANSACTION_FEE);
 CAmount maxTxFee = DEFAULT_TRANSACTION_MAXFEE;
-unsigned int nTxConfirmTarget = 1;
+unsigned int nTxConfirmTarget = 2;
 bool bSpendZeroConfChange = true;
 bool fSendFreeTransactions = false;
 bool fPayAtLeastCustomFee = true;


### PR DESCRIPTION
Changing default confirm target for fee estimation from 1 to 2 due to : 

https://github.com/litecoin-project/litecoin/issues/211

