### PR TITLE
Increase OP_ RETURN relay to 80 bytes

### DIFF
--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -25,7 +25,7 @@ public:
     CScriptID(const uint160& in) : uint160(in) {}
 };
 
-static const unsigned int MAX_OP_RETURN_RELAY = 40;      //! bytes
+static const unsigned int MAX_OP_RETURN_RELAY = 80;      //! bytes
 extern unsigned nMaxDatacarrierBytes;
 
 /**


### PR DESCRIPTION
Bitcoin Core 0.11 increased the `OP_RETURN` relay to 80 bytes.