### PR TITLE
Litecoin: Fix p2p-compactblocks.py test hang

### DIFF
--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -10,6 +10,8 @@ from test_framework.blocktools import create_block, create_coinbase, add_witness
 from test_framework.siphash import siphash256
 from test_framework.script import CScript, OP_TRUE
 
+VB_TOP_BITS = 0x20000000
+
 '''
 CompactBlocksTest -- test compact blocks (BIP 152)
 
@@ -128,7 +130,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         tip = node.getbestblockhash()
         mtp = node.getblockheader(tip)['mediantime']
         block = create_block(int(tip, 16), create_coinbase(height + 1), mtp + 1)
-        block.nVersion = 4
+        block.nVersion = VB_TOP_BITS
         if segwit:
             add_witness_commitment(block)
         block.solve()


### PR DESCRIPTION
Changed nVersion to BIP9_TOP_BITS to prevent the test hanging.