### PR TITLE
Fix IsInitialBlockDownload which was broken by headers first

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1265,7 +1265,7 @@ bool IsInitialBlockDownload()
     if (lockIBDState)
         return false;
     bool state = (chainActive.Height() < pindexBestHeader->nHeight - 24 * 6 ||
-            pindexBestHeader->GetBlockTime() < GetTime() - chainParams.MaxTipAge());
+            pindexBestHeader->GetBlockTime() < GetTime() - 24 * 60 * 60);
     if (!state)
         lockIBDState = true;
     return state;


### PR DESCRIPTION
Referenced in https://github.com/bitcoin/bitcoin/commit/a2d0fc658a7b21d2d41ef2a6c657d24114b6c49e.
This causes incorrect behaviour on client startup where new block has not been discovered for several hours, prevents node from creating new block 'Litecoin is downloading blocks...'.