### PR TITLE
Fixed sentence in wallet/crypter.h

### DIFF
--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -58,7 +58,7 @@ public:
     CMasterKey()
     {
         // 25000 rounds is just under 0.1 seconds on a 1.86 GHz Pentium M
-        // ie slightly lower than the lowest hardware we need bother supporting
+        // i.e. slightly lower than the lowest hardware we need to bother supporting
         nDeriveIterations = 25000;
         nDerivationMethod = 0;
         vchOtherDerivationParameters = std::vector<unsigned char>(0);


### PR DESCRIPTION
Added punctuation for _id est_ and added the missing word "to" which made the sentence incomplete.