### PR TITLE
freebsd compilation fix

### DIFF
--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -43,7 +43,7 @@
 #include <cpuid.h>
 #endif
 #endif
-
+#ifndef __FreeBSD__
 static inline uint32_t be32dec(const void *pp)
 {
 	const uint8_t *p = (uint8_t const *)pp;
@@ -60,6 +60,7 @@ static inline void be32enc(void *pp, uint32_t x)
 	p[0] = (x >> 24) & 0xff;
 }
 
+#endif
 typedef struct HMAC_SHA256Context {
 	SHA256_CTX ictx;
 	SHA256_CTX octx;

--- a/src/crypto/scrypt.h
+++ b/src/crypto/scrypt.h
@@ -28,6 +28,7 @@ void
 PBKDF2_SHA256(const uint8_t *passwd, size_t passwdlen, const uint8_t *salt,
     size_t saltlen, uint64_t c, uint8_t *buf, size_t dkLen);
 
+#ifndef __FreeBSD__
 static inline uint32_t le32dec(const void *pp)
 {
         const uint8_t *p = (uint8_t const *)pp;
@@ -43,4 +44,5 @@ static inline void le32enc(void *pp, uint32_t x)
         p[2] = (x >> 16) & 0xff;
         p[3] = (x >> 24) & 0xff;
 }
+#endif
 #endif


### PR DESCRIPTION
be32enc() andn le32dec() are already declared in /usr/include/sys/endian.h under freebsd 11