### PR TITLE
fee reduction: reduce dust, fallback, and default tx min fee configs

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -43,7 +43,7 @@ static const unsigned int MAX_STANDARD_P2WSH_SCRIPT_SIZE = 3600;
  * standard and should be done with care and ideally rarely. It makes sense to
  * only increase the dust limit after prior releases were already not creating
  * outputs below the new threshold */
-static const unsigned int DUST_RELAY_TX_FEE = 300000;
+static const unsigned int DUST_RELAY_TX_FEE = 3000;
 /**
  * Standard script verification flags that standard transactions will comply
  * with. However scripts violating these flags may still be present in valid

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -693,7 +693,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
 
     // Check dust with default relay fee:
     CAmount nDustThreshold = 182 * dustRelayFee.GetFeePerK()/1000;
-    BOOST_CHECK_EQUAL(nDustThreshold, 54600);
+    BOOST_CHECK_EQUAL(nDustThreshold, 546);
     // dust:
     t.vout[0].nValue = nDustThreshold - 1;
     BOOST_CHECK(!IsStandardTx(t, reason));

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -44,11 +44,11 @@ static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
 //! -paytxfee default
 static const CAmount DEFAULT_TRANSACTION_FEE = 0;
 //! -fallbackfee default
-static const CAmount DEFAULT_FALLBACK_FEE = 2000000;
+static const CAmount DEFAULT_FALLBACK_FEE = 20000;
 //! -m_discard_rate default
 static const CAmount DEFAULT_DISCARD_FEE = 10000;
 //! -mintxfee default
-static const CAmount DEFAULT_TRANSACTION_MINFEE = 100000;
+static const CAmount DEFAULT_TRANSACTION_MINFEE = 1000;
 //! minimum recommended increment for BIP 125 replacement txs
 static const CAmount WALLET_INCREMENTAL_RELAY_FEE = 5000;
 //! target minimum change amount


### PR DESCRIPTION
related to https://github.com/litecoin-project/litecoin/commit/98d755d14034f116f6da83049ccc2d20fe04cb38

`DEFAULT_TRANSACTION_MINFEE` is awkward in the wallet GUI without this update. I also think it makes sense to reduce the other fee configs in this PR at the same time.