### PR TITLE
Litecoin: Basic changes for v0.16 release

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1347,6 +1347,7 @@ echo "  with test     = $use_tests"
 echo "  with bench    = $use_bench"
 echo "  with upnp     = $use_upnp"
 echo "  use asm       = $use_asm"
+echo "  scrypt sse2   = $use_sse2"
 echo "  debug enabled = $enable_debug"
 echo "  werror        = $enable_werror"
 echo

--- a/doc/README.md
+++ b/doc/README.md
@@ -51,7 +51,6 @@ The Litecoin repo's [root README](/README.md) contains relevant information on t
 - [Developer Notes](developer-notes.md)
 - [Release Notes](release-notes.md)
 - [Release Process](release-process.md)
-- [Source Code Documentation (External Link)](https://dev.visucore.com/litecoin/doxygen/)
 - [Translation Process](translation_process.md)
 - [Translation Strings Policy](translation_strings_policy.md)
 - [Travis CI](travis-ci.md)

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -70,6 +70,16 @@ Build Litecoin Core
 
         make deploy
 
+5.  Installation into user directories (optional):
+
+        make install
+
+    or
+
+        cd ~/litecoin/src
+        cp litecoind /usr/local/bin/
+        cp litecoin-cli /usr/local/bin/
+
 Running
 -------
 

--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -313,7 +313,7 @@ std::string scrypt_detect_sse2()
     if (cpuid_edx & 1<<26)
     {
         scrypt_1024_1_1_256_sp_detected = &scrypt_1024_1_1_256_sp_sse2;
-        ret = "scrypt: using scrypt-sse2 as detected");
+        ret = "scrypt: using scrypt-sse2 as detected";
     }
     else
     {

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -280,7 +280,7 @@ static void http_reject_request_cb(struct evhttp_request* req, void*)
 /** Event dispatcher thread */
 static bool ThreadHTTP(struct event_base* base, struct evhttp* http)
 {
-    RenameThread("bitcoin-http");
+    RenameThread("litecoin-http");
     LogPrint(BCLog::HTTP, "Entering http event loop\n");
     event_base_dispatch(base);
     // Event loop will be interrupted by InterruptHTTPServer()
@@ -329,7 +329,7 @@ static bool HTTPBindAddresses(struct evhttp* http)
 /** Simple wrapper to set thread name and run work queue */
 static void HTTPWorkQueueRun(WorkQueue<HTTPClosure>* queue)
 {
-    RenameThread("bitcoin-httpworker");
+    RenameThread("litecoin-httpworker");
     queue->Run();
 }
 


### PR DESCRIPTION
Fixes: https://github.com/litecoin-project/litecoin/issues/463
Adds additional build instructions for macOS

Addresses: https://github.com/litecoin-project/litecoin/pull/465
Removes dead link of readme page

Addresses: https://github.com/litecoin-project/litecoin/pull/462
Renames threads to be in line with Litecoin branding

Minor configure change which shows whether scrypt sse2 is enabled/disabled and fixes a syntax error.

