### PR TITLE
Fix CVE-2018-12356 by hardening the regex.

### DIFF
--- a/contrib/verify-commits/gpg.sh
+++ b/contrib/verify-commits/gpg.sh
@@ -57,7 +57,7 @@ if ! $VALID; then
 	exit 1
 fi
 if $VALID && $REVSIG; then
-	printf '%s\n' "$INPUT" | gpg --trust-model always "$@" 2>/dev/null | grep "\[GNUPG:\] \(NEWSIG\|SIG_ID\|VALIDSIG\)"
+	printf '%s\n' "$INPUT" | gpg --trust-model always "$@" 2>/dev/null | grep "^\[GNUPG:\] \(NEWSIG\|SIG_ID\|VALIDSIG\)"
 	echo "$GOODREVSIG"
 else
 	printf '%s\n' "$INPUT" | gpg --trust-model always "$@" 2>/dev/null


### PR DESCRIPTION
Detailed write-up here:
https://neopg.io/blog/pass-signature-spoof/