### PR TITLE
Add dnsseed.testnetpool.com to DNS seeds

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -233,6 +233,7 @@ public:
         vSeeds.emplace_back("testnet-seed.litecointools.com");
         vSeeds.emplace_back("seed-b.litecoin.loshan.co.uk");
         vSeeds.emplace_back("dnsseed-testnet.thrasher.io");
+        vSeeds.emplace_back("dnsseed.testnetpool.com");
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);


### PR DESCRIPTION
Add my Litecoin testnet DNS seed (dnsseed.testnetpool.com) to the list of hard-coded DNS seeds. Note; my seed node's NS records are still updating, but will be correct in about an hour at the time of writing.