### PR TITLE
configure: display build OS.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1588,7 +1588,7 @@ echo "  gprof enabled = $enable_gprof"
 echo "  werror        = $enable_werror"
 echo
 echo "  target os     = $TARGET_OS"
-echo "  build os      = $BUILD_OS"
+echo "  build os      = $build_os"
 echo
 echo "  CC            = $CC"
 echo "  CFLAGS        = $CFLAGS"


### PR DESCRIPTION
Greetings.

This PR fixes the string "build os" in the configure script.

for instance, here is the output once it is fixed:

`
  target os     = linux
  build os      = linux-gnu
`

