### PR TITLE
Trivial: fix comment on regression testnet nPowTargetTimespan

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -281,7 +281,7 @@ public:
         consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in functional tests)
         consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in functional tests)
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.nPowTargetTimespan = 3.5 * 24 * 60 * 60; // two weeks
+        consensus.nPowTargetTimespan = 3.5 * 24 * 60 * 60; // 3.5 days
         consensus.nPowTargetSpacing = 2.5 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = true;


### PR DESCRIPTION
While changing `consensus.nPowTargetTimespan` on the Regression test for an altcoin I'm currently working on (a Litecoin fork), I noticed that the comment next to it said "two weeks" while the code said 3.5 days, so I changed it.