### PR TITLE
build: macOS notarisation process

### DIFF
--- a/contrib/macdeploy/detached-sig-create.sh
+++ b/contrib/macdeploy/detached-sig-create.sh
@@ -23,7 +23,7 @@ fi
 rm -rf ${TEMPDIR} ${TEMPLIST}
 mkdir -p ${TEMPDIR}
 
-${CODESIGN} -f --file-list ${TEMPLIST} "$@" "${BUNDLE}"
+${CODESIGN} -f --options runtime --timestamp --deep --file-list ${TEMPLIST} "$@" "${BUNDLE}"
 
 grep -v CodeResources < "${TEMPLIST}" | while read i; do
   TARGETFILE="${BUNDLE}/$(echo "${i}" | sed "s|.*${BUNDLE}/||")"


### PR DESCRIPTION
Based on upstream PR https://github.com/bitcoin/bitcoin/pull/18187

Apple now requires the prior notarisation of binaries distributed outside of the Mac App Store, including Litecoin Core.
The PR aims to fix incorrect codesign params, as now required for notarisation by Apple. 
This PR also includes additional documentation for the macOS codesigner to generate the codesign receipts used for signed Gitian builds. 