### PR TITLE
Fix undefined reference to `CHDChain::VERSION_HD_CHAIN_SPLIT'

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -56,6 +56,12 @@ const std::string WATCHMETA{"watchmeta"};
 const std::string WATCHS{"watchs"};
 } // namespace DBKeys
 
+const int CHDChain::VERSION_HD_BASE;
+const int CHDChain::VERSION_HD_CHAIN_SPLIT;
+const int CHDChain::VERSION_HD_MWEB;
+const int CHDChain::VERSION_HD_MWEB_WATCH;
+const int CHDChain::CURRENT_VERSION;
+
 //
 // WalletBatch
 //


### PR DESCRIPTION
This fixes issue #833.

The class `CHDChain` contains `static const` variables initialized in-line:

```
class CHDChain
{
. . .
    static const int VERSION_HD_BASE        = 1;
    static const int VERSION_HD_CHAIN_SPLIT = 2;
```

That is risky from an ODR perspective - if the variables are ODR-used, there will be ODR violations.

https://en.cppreference.com/w/cpp/language/static#Constant_static_members

> If a const non-inline (since C++17) static data member or a constexpr static data member (since C++11)(until C++17) is [odr-used](https://en.cppreference.com/w/cpp/language/definition#ODR-use), a definition at namespace scope is still required, but it cannot have an initializer. A definition may be provided even though redundant (since C++17).

This PR provides the missing definitions in the **.cpp** file.