### PR TITLE
Update GetHeight() for empty checkpoint data

### DIFF
--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -25,6 +25,9 @@ struct CCheckpointData {
     MapCheckpoints mapCheckpoints;
 
     int GetHeight() const {
+        if(mapCheckpoints.empty())
+            return 0;
+        
         const auto& final_checkpoint = mapCheckpoints.rbegin();
         return final_checkpoint->first /* height */;
     }


### PR DESCRIPTION
When checkpoint map is empty, litecoin throws a segmentation fault. This commit fixes it