### PR TITLE
Adjust Reserve Space for Coinbase Tx

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -88,8 +88,8 @@ void BlockAssembler::resetBlock()
     inBlock.clear();
 
     // Reserve space for coinbase tx
-    nBlockWeight = 4000;
-    nBlockSigOpsCost = 400;
+    nBlockWeight = 2000;
+    nBlockSigOpsCost = 200;
     nBlockMWEBWeight = 0;
     fIncludeWitness = false;
     fIncludeMWEB = false;


### PR DESCRIPTION
The average tx size is 400 bytes.

Not sure if this was 4Xed with the addition of SegWit. But a 4K reserve for the coinbase tx is excessive. 1K is probably just enough and on the low side, so I am proposing 2K as a safe and conservative optimum value.