### PR TITLE
Fix Broken Linux Compiling Dependancies Instruction

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -77,7 +77,7 @@ Finally, clang (often less resource hungry) can be used instead of gcc, which is
 
 Build requirements:
 
-    sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils python3
+    sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils python3 libssl-dev
 
 Now, you can either build from self-compiled [depends](/depends/README.md) or install the required dependencies:
 


### PR DESCRIPTION
Add libssl-dev which is required for Linux Compiling




