### PR TITLE
Add missing includes

### DIFF
--- a/src/support/lockedpool.h
+++ b/src/support/lockedpool.h
@@ -5,11 +5,12 @@
 #ifndef BITCOIN_SUPPORT_LOCKEDPOOL_H
 #define BITCOIN_SUPPORT_LOCKEDPOOL_H
 
-#include <stdint.h>
 #include <list>
 #include <map>
-#include <mutex>
 #include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <stdint.h>
 #include <unordered_map>
 
 /**

--- a/src/util/bip32.h
+++ b/src/util/bip32.h
@@ -6,6 +6,7 @@
 #define BITCOIN_UTIL_BIP32_H
 
 #include <attributes.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <array>
 #include <cstring>
+#include <cstdint>
 #include <locale>
 #include <sstream>
 #include <string>


### PR DESCRIPTION

I could not compile the project with `--enable-wallet` because these includes in headers were missing. Maybe I was missing some flag that includes them automatically?

Anyway, I was lazy to make an issue about it. Take it or close it.