### PR TITLE
Fixed an issue where transaction indexes of block could be lost,

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -127,12 +127,6 @@ void BaseIndex::ThreadSync()
                 last_log_time = current_time;
             }
 
-            if (last_locator_write_time + SYNC_LOCATOR_WRITE_INTERVAL < current_time) {
-                m_best_block_index = pindex;
-                last_locator_write_time = current_time;
-                // No need to handle errors in Commit. See rationale above.
-                Commit();
-            }
 
             CBlock block;
             if (!ReadBlockFromDisk(block, pindex, consensus_params)) {
@@ -144,6 +138,13 @@ void BaseIndex::ThreadSync()
                 FatalError("%s: Failed to write block %s to index database",
                            __func__, pindex->GetBlockHash().ToString());
                 return;
+            }
+
+            if (last_locator_write_time + SYNC_LOCATOR_WRITE_INTERVAL < current_time) {
+                m_best_block_index = pindex;
+                last_locator_write_time = current_time;
+                // No need to handle errors in Commit. See rationale above.
+                Commit();
             }
         }
     }


### PR DESCRIPTION
The problems I encountered:

I have done customization development in WriteBlock(block, pindex) and WriteBlock(block, pindex) maybe return false, where i restart the node and find that the transaction cannot be obtained through the transaction index


Here's why:
If run Commit() first, then WriteBlock(block, pindex), At this time, the transaction indexed of the block has been marked as successfully created, but if WriteBlock(block, pindex) fails to be run, the transaction index is not really created, and the transaction data will not be found out through the transaction index. so WriteBlock(block, pindex) must be executed first before committing () is executed.


