### PR TITLE
fix build dependencies (boost, qt) with gcc-11

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -3,7 +3,7 @@ $(package)_version=1_70_0
 $(package)_download_path=https://dl.bintray.com/boostorg/release/1.70.0/source/
 $(package)_file_name=boost_$($(package)_version).tar.bz2
 $(package)_sha256_hash=430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778
-$(package)_patches=unused_var_in_process.patch
+$(package)_patches=unused_var_in_process.patch ignore_wnonnull_gcc_11.patch commit-74fb0a2.patch commit-f9d0e59.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
@@ -34,6 +34,9 @@ endef
 
 define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/unused_var_in_process.patch && \
+  patch -p2 -i $($(package)_patch_dir)/ignore_wnonnull_gcc_11.patch && \
+  patch -p2 -i $($(package)_patch_dir)/commit-74fb0a2.patch && \
+  patch -p2 -i $($(package)_patch_dir)/commit-f9d0e59.patch && \
   echo "using $($(package)_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$($(package)_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
 endef
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -12,6 +12,8 @@ $(package)_patches=fix_qt_pkgconfig.patch mac-qmake.conf fix_configure_mac.patch
 $(package)_patches+= fix_rcc_determinism.patch fix_riscv64_arch.patch xkb-default.patch no-xlib.patch
 $(package)_patches+= fix_android_qmake_conf.patch fix_android_jni_static.patch dont_hardcode_pwd.patch
 $(package)_patches+= freetype_back_compat.patch drop_lrelease_dependency.patch fix_powerpc_libpng.patch
+$(package)_patches+= fix_limits_header.patch
+
 
 # Update OSX_QT_TRANSLATIONS when this is updated
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
@@ -217,6 +219,7 @@ define $(package)_preprocess_cmds
   echo "!host_build: QMAKE_LFLAGS     += $($(package)_ldflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
   patch -p1 -i $($(package)_patch_dir)/fix_riscv64_arch.patch &&\
   patch -p1 -i $($(package)_patch_dir)/no-xlib.patch &&\
+  patch -p1 -i $($(package)_patch_dir)/fix_limits_header.patch && \
   echo "QMAKE_LINK_OBJECT_MAX = 10" >> qtbase/mkspecs/win32-g++/qmake.conf &&\
   echo "QMAKE_LINK_OBJECT_SCRIPT = object_script" >> qtbase/mkspecs/win32-g++/qmake.conf &&\
   sed -i.old "s|QMAKE_CFLAGS           += |!host_build: QMAKE_CFLAGS            = $($(package)_cflags) $($(package)_cppflags) |" qtbase/mkspecs/win32-g++/qmake.conf && \

--- a/depends/patches/boost/commit-74fb0a2.patch
+++ b/depends/patches/boost/commit-74fb0a2.patch
@@ -1,0 +1,19 @@
+From 74fb0a26099bc51d717f5f154b37231ce7df3e98 Mon Sep 17 00:00:00 2001
+From: Rob Boehne <robb@datalogics.com>
+Date: Wed, 20 Nov 2019 11:25:20 -0600
+Subject: Revert change to elide a warning that caused Solaris builds to fail.
+
+
+diff --git a/include/boost/thread/pthread/thread_data.hpp b/include/boost/thread/pthread/thread_data.hpp
+index aefbeb43..bc9b1367 100644
+--- a/include/boost/thread/pthread/thread_data.hpp
++++ b/include/boost/thread/pthread/thread_data.hpp
+@@ -57,7 +57,7 @@ namespace boost
+ #else
+           std::size_t page_size = ::sysconf( _SC_PAGESIZE);
+ #endif
+-#if PTHREAD_STACK_MIN > 0
++#ifdef PTHREAD_STACK_MIN
+           if (size<PTHREAD_STACK_MIN) size=PTHREAD_STACK_MIN;
+ #endif
+           size = ((size+page_size-1)/page_size)*page_size;

--- a/depends/patches/boost/commit-f9d0e59.patch
+++ b/depends/patches/boost/commit-f9d0e59.patch
@@ -1,0 +1,26 @@
+From f9d0e594d43afcb4ab0043117249feb266ba4515 Mon Sep 17 00:00:00 2001
+From: Romain Geissler <romain.geissler@amadeus.com>
+Date: Tue, 10 Aug 2021 14:22:28 +0000
+Subject: Fix -Wsign-compare warning with glibc 2.34 on Linux platforms.
+
+In file included from /data/mwrep/res/osp/Boost/21-0-0-0/include/boost/thread/thread_only.hpp:17,
+                 from /data/mwrep/res/osp/Boost/21-0-0-0/include/boost/thread/thread.hpp:12,
+                 from src/GetTest.cpp:12:
+/data/mwrep/res/osp/Boost/21-0-0-0/include/boost/thread/pthread/thread_data.hpp: In member function 'void boost::thread_attributes::set_stack_size(std::size_t)':
+/data/mwrep/res/osp/Boost/21-0-0-0/include/boost/thread/pthread/thread_data.hpp:61:19: error: comparison of integer expressions of different signedness: 'std::size_t' {aka 'long unsigned int'} and 'long int' [-Werror=sign-compare]
+   61 |           if (size<PTHREAD_STACK_MIN) size=PTHREAD_STACK_MIN;
+      |                   ^
+
+diff --git a/include/boost/thread/pthread/thread_data.hpp b/include/boost/thread/pthread/thread_data.hpp
+index bc9b1367..c43b276d 100644
+--- a/include/boost/thread/pthread/thread_data.hpp
++++ b/include/boost/thread/pthread/thread_data.hpp
+@@ -58,7 +58,7 @@ namespace boost
+           std::size_t page_size = ::sysconf( _SC_PAGESIZE);
+ #endif
+ #ifdef PTHREAD_STACK_MIN
+-          if (size<PTHREAD_STACK_MIN) size=PTHREAD_STACK_MIN;
++          if (size<static_cast<std::size_t>(PTHREAD_STACK_MIN)) size=PTHREAD_STACK_MIN;
+ #endif
+           size = ((size+page_size-1)/page_size)*page_size;
+           int res = pthread_attr_setstacksize(&val_, size);

--- a/depends/patches/boost/ignore_wnonnull_gcc_11.patch
+++ b/depends/patches/boost/ignore_wnonnull_gcc_11.patch
@@ -1,0 +1,68 @@
+diff --git a/include/boost/concept/detail/general.hpp b/include/boost/concept/detail/general.hpp
+index eeb08750..8d7d6f69 100644
+--- a/include/boost/concept/detail/general.hpp
++++ b/include/boost/concept/detail/general.hpp
+@@ -28,7 +28,14 @@ namespace detail
+ template <class Model>
+ struct requirement
+ {
++#   if defined(BOOST_GCC) && (BOOST_GCC >= 110000)
++#   pragma GCC diagnostic push
++#   pragma GCC diagnostic ignored "-Wnonnull"
++#   endif
+     static void failed() { ((Model*)0)->~Model(); }
++#   if defined(BOOST_GCC) && (BOOST_GCC >= 110000)
++#   pragma GCC diagnostic pop
++#   endif
+ };
+ 
+ struct failed {};
+@@ -36,7 +43,14 @@ struct failed {};
+ template <class Model>
+ struct requirement<failed ************ Model::************>
+ {
++#   if defined(BOOST_GCC) && (BOOST_GCC >= 110000)
++#   pragma GCC diagnostic push
++#   pragma GCC diagnostic ignored "-Wnonnull"
++#   endif
+     static void failed() { ((Model*)0)->~Model(); }
++#   if defined(BOOST_GCC) && (BOOST_GCC >= 110000)
++#   pragma GCC diagnostic pop
++#   endif
+ };
+ 
+ # ifdef BOOST_OLD_CONCEPT_SUPPORT
+@@ -44,7 +58,14 @@ struct requirement<failed ************ Model::************>
+ template <class Model>
+ struct constraint
+ {
++#   if defined(BOOST_GCC) && (BOOST_GCC >= 110000)
++#   pragma GCC diagnostic push
++#   pragma GCC diagnostic ignored "-Wnonnull"
++#   endif
+     static void failed() { ((Model*)0)->constraints(); }
++#   if defined(BOOST_GCC) && (BOOST_GCC >= 110000)
++#   pragma GCC diagnostic pop
++#   endif
+ };
+   
+ template <class Model>
+diff --git a/include/boost/concept/usage.hpp b/include/boost/concept/usage.hpp
+index 373de63a..fe88b5f5 100644
+--- a/include/boost/concept/usage.hpp
++++ b/include/boost/concept/usage.hpp
+@@ -13,7 +13,14 @@ namespace boost { namespace concepts {
+ template <class Model>
+ struct usage_requirements
+ {
++#   if defined(BOOST_GCC) && (BOOST_GCC >= 110000)
++#   pragma GCC diagnostic push
++#   pragma GCC diagnostic ignored "-Wnonnull"
++#   endif
+     ~usage_requirements() { ((Model*)0)->~Model(); }
++#   if defined(BOOST_GCC) && (BOOST_GCC >= 110000)
++#   pragma GCC diagnostic pop
++#   endif
+ };
+ 
+ #  if BOOST_WORKAROUND(__GNUC__, <= 3)

--- a/depends/patches/qt/fix_limits_header.patch
+++ b/depends/patches/qt/fix_limits_header.patch
@@ -1,0 +1,43 @@
+Fix compiling with GCC 11
+
+See: https://bugreports.qt.io/browse/QTBUG-90395.
+
+Upstream commits:
+ - Qt 5.15 -- unavailable as open source
+ - Qt 6.0: b2af6332ea37e45ab230a7a5d2d278f86d961b83
+ - Qt 6.1: 9c56d4da2ff631a8c1c30475bd792f6c86bda53c
+
+--- old/qtbase/src/corelib/global/qendian.h
++++ new/qtbase/src/corelib/global/qendian.h
+@@ -44,6 +44,8 @@
+ #include <QtCore/qfloat16.h>
+ #include <QtCore/qglobal.h>
+ 
++#include <limits>
++
+ // include stdlib.h and hope that it defines __GLIBC__ for glibc-based systems
+ #include <stdlib.h>
+ #include <string.h>
+
+--- old/qtbase/src/corelib/tools/qbytearraymatcher.h
++++ new/qtbase/src/corelib/tools/qbytearraymatcher.h
+@@ -42,6 +42,8 @@
+ 
+ #include <QtCore/qbytearray.h>
+ 
++#include <limits>
++
+ QT_BEGIN_NAMESPACE
+ 
+ 
+
+--- old/qtbase/src/tools/moc/generator.cpp
++++ new/qtbase/src/tools/moc/generator.cpp
+@@ -36,6 +36,7 @@
+ #include <QtCore/qjsonvalue.h>
+ #include <QtCore/qjsonarray.h>
+ #include <QtCore/qplugin.h>
++#include <limits>
+ #include <stdio.h>
+ 
+ #include <private/qmetaobject_p.h> //for the flags.


### PR DESCRIPTION
This PR fixes the build of dependencies (Boost, Qt) on modern Linux distributions (such as Ubuntu 22.04.5 LTS) with GCC 11.x installed. Without these fixes, attempting to build dependencies with GCC 11 using:

```bash
make -C ${PWD}/depends V=1 HOST=$(depends/config.guess) -j$(nproc --all)
```

will result in various errors. This PR introduces patches that are present in newer versions of Boost and Qt, resolving the issues with the GCC 11.x build.

Build errors and warnings:

1. Error. Solved in `ignore_wnonnull_gcc_11.patch`:
```
./boost/concept/usage.hpp:16:48: warning: ‘this’ pointer is null [-Wnonnull]
   16 |     ~usage_requirements() { ((Model*)0)->~Model(); }
      |                             ~~~~~~~~~~~~~~~~~~~^~
./boost/concept/usage.hpp:30:7: note: in a call to non-static member function ‘boost::SinglePassRangeConcept<T>::~SinglePassRangeConcept() [with T = const boost::iterator_range<__gnu_cxx::__normal_iterator<char*, std::__cxx11::basic_string<char> > >]’
   30 |       ~model()
      |       ^
./boost/range/concepts.hpp:284:9: note: in expansion of macro ‘BOOST_CONCEPT_USAGE’
  284 |         BOOST_CONCEPT_USAGE(SinglePassRangeConcept)
      |         ^~~~~~~~~~~~~~~~~~~
...failed gcc.compile.c++ bin.v2/libs/thread/build/gcc-11.4.0/release/link-static/threadapi-pthread/threading-multi/visibility-hidden/pthread/thread.o...
```
2. Error. Solved in `commit-74fb0a2.patch`:
```
./boost/thread/pthread/thread_data.hpp:60:5: error: missing binary operator before token "("
   60 | #if PTHREAD_STACK_MIN > 0
      |     ^~~~~~~~~~~~~~~~~
...failed gcc.compile.c++ bin.v2/libs/thread/build/gcc-11.4.0/release/link-static/threadapi-pthread/threading-multi/visibility-hidden/pthread/thread.o...
```
3. Warning. Solved in `commit-f9d0e59.patch`:
```
./boost/thread/pthread/thread_data.hpp: In member function ‘void boost::thread_attributes::set_stack_size(std::size_t)’:
./boost/thread/pthread/thread_data.hpp:61:19: warning: comparison of integer expressions of different signedness: ‘std::size_t’ {aka ‘long unsigned int’} and ‘long int’ [-Wsign-compare]
   61 |           if (size<PTHREAD_STACK_MIN) size=PTHREAD_STACK_MIN;
      |                   ^
RmTemps bin.v2/libs/thread/build/gcc-11.4.0/release/link-static/threadapi-pthread/threading-multi/visibility-hidden/libboost_thread-mt-x64.a(clean)
```
4. Qt. Missed `limits` header - https://bugreports.qt.io/browse/QTBUG-90395 . Solved in `fix_limits_header.patch`.