### PR TITLE
wallet, rpc: add MWEB view keys to dumpwallet

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -805,6 +805,14 @@ RPCHelpMan dumpwallet()
             file << "# extended private masterkey: " << EncodeExtKey(masterKey) << "\n\n";
         }
     }
+
+    SecretKey scan_secret = spk_man.GetScanSecret();
+    SecretKey spend_secret = spk_man.GetSpendSecret();
+    if (!scan_secret.IsNull() && !spend_secret.IsNull())
+    {
+        file << "# mweb view keys: " << scan_secret.ToHex() << " " << PublicKey::From(spend_secret).ToHex() << "\n\n";
+    }
+
     for (std::vector<std::pair<int64_t, CKeyID> >::const_iterator it = vKeyBirth.begin(); it != vKeyBirth.end(); it++) {
         const CKeyID &keyid = it->second;
         std::string strTime = FormatISO8601DateTime(it->first);

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -532,6 +532,14 @@ public:
         
         return SecretKey::Null();
     };
+    SecretKey GetSpendSecret() const noexcept
+    {
+        if (m_mwebKeychain) {
+            return m_mwebKeychain->GetSpendSecret();
+        }
+
+        return SecretKey::Null();
+    };
 };
 
 /** Wraps a LegacyScriptPubKeyMan so that it can be returned in a new unique_ptr. Does not provide privkeys */


### PR DESCRIPTION
Dump MWEB view keys (scan secret and spend pubkey) for use in e.g. BTCPayServer.