### PR TITLE
build: wallet: Fix wallet with boost library >= 1.78

### DIFF
--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -22,7 +22,11 @@ bool VerifyWallets(interfaces::Chain& chain)
         fs::path wallet_dir = gArgs.GetArg("-walletdir", "");
         boost::system::error_code error;
         // The canonical path cleans the path, preventing >1 Berkeley environment instances for the same directory
+#if BOOST_VERSION >= 107800
+        fs::path canonical_wallet_dir = fs::canonical(wallet_dir, error).remove_trailing_separator();
+#else
         fs::path canonical_wallet_dir = fs::canonical(wallet_dir, error);
+#endif
         if (error || !fs::exists(wallet_dir)) {
             chain.initError(strprintf(_("Specified -walletdir \"%s\" does not exist"), wallet_dir.string()));
             return false;

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -22,11 +22,7 @@ bool VerifyWallets(interfaces::Chain& chain)
         fs::path wallet_dir = gArgs.GetArg("-walletdir", "");
         boost::system::error_code error;
         // The canonical path cleans the path, preventing >1 Berkeley environment instances for the same directory
-#if BOOST_VERSION >= 107800
         fs::path canonical_wallet_dir = fs::canonical(wallet_dir, error).remove_trailing_separator();
-#else
-        fs::path canonical_wallet_dir = fs::canonical(wallet_dir, error);
-#endif
         if (error || !fs::exists(wallet_dir)) {
             chain.initError(strprintf(_("Specified -walletdir \"%s\" does not exist"), wallet_dir.string()));
             return false;


### PR DESCRIPTION
The line that fixes the issue comes from bitcoin#24104. I gated it with the boost library version as I'm not aware if it would be backward compatible or not.
fixes #932

I wasn't sure if I should use "build:" or "wallet:" for the start of the title because it's a wallet change but really only to fix the build for the later boost libraries.  Hopefully using both is acceptable for this case?  Let me know if I should do something different in the future.