### PR TITLE
Add <cstdint> include to fix build error.

### DIFF
--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <string>
+#include <cstdint>
 
 class ArgsManager;
 

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 #include <string>
+#include <cstdint>
 
 class CBlockIndex;
 class CTransaction;


### PR DESCRIPTION
When building on Debian, the following error is received (manifested multiple times):

```
./chainparamsbase.h:38:11: error: ‘uint16_t’ does not name a type
   38 |     const uint16_t m_onion_service_target_port;
      |           ^~~~~~~~
./chainparamsbase.h:38:11: note: ‘uint16_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
```

https://salsa.debian.org/debian/litecoin/-/jobs/8822668#L3139

This PR adds two instances of `#include <cstdint>`, which resolve this build issue.