### PR TITLE
net: Fix build with miniupnpc 2.2.8 (API version 18+)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1637,7 +1637,12 @@ static void ThreadMapPort()
     struct IGDdatas data;
     int r;
 
+#if MINIUPNPC_API_VERSION >= 18
+    char errorMsg[256];
+    r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr), errorMsg, sizeof(errorMsg));
+#else
     r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr));
+#endif
     if (r == 1)
     {
         if (fDiscover) {


### PR DESCRIPTION
## Summary

Fixes build failure with miniupnpc >= 2.2.8 by adding conditional compilation for the changed `UPNP_GetValidIGD()` API.

## Problem

As reported in [Debian Bug #1087899](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1087899), Litecoin 0.21.4 fails to build with miniupnpc 2.2.8:

```
net.cpp:1640:25: error: too few arguments to function 'int UPNP_GetValidIGD(...)'
```

## Solution

miniupnpc API version 18 added two new parameters to `UPNP_GetValidIGD()`:
- `char *errorMsg` - buffer for error messages
- `int errorMsgLen` - size of error buffer

This PR adds conditional compilation to use the correct API based on version:

```cpp
#if MINIUPNPC_API_VERSION >= 18
    char errorMsg[256];
    r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr), 
                         errorMsg, sizeof(errorMsg));
#else
    r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr));
#endif
```

## Credits

Patch originally proposed by Gui-Yue <yuemeng.gui@gmail.com> in issue #1004.

## Test plan

- [x] Compiles with miniupnpc < 2.2.8 (uses old API)
- [x] Compiles with miniupnpc >= 2.2.8 (uses new API)

Closes #1004

---
Generated with [Claude Code](https://claude.com/claude-code)