### PR TITLE
qt: Add missing <limits> header for GCC 11+ compatibility

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -20,6 +20,8 @@
 #include <script/standard.h>
 #include <util/system.h>
 
+#include <limits>
+
 #ifdef WIN32
 #ifndef NOMINMAX
 #define NOMINMAX

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -19,6 +19,8 @@
 #include <netbase.h>
 #include <txdb.h> // for -dbcache defaults
 
+#include <limits>
+
 #include <QDataWidgetMapper>
 #include <QDir>
 #include <QIntValidator>


### PR DESCRIPTION
## Summary

Adds explicit `#include <limits>` to Qt source files to fix build failures with GCC 11+.

## Problem

GCC 11 changed header dependencies in libstdc++. Headers that previously transitively included `<limits>` no longer do, causing build failures when `std::numeric_limits` is used without an explicit include.

Error:
```
error: numeric_limits is not a member of std
```

## Solution

Add explicit `#include <limits>` to the affected Qt files:
- `src/qt/guiutil.cpp`
- `src/qt/optionsdialog.cpp`

## Reference

From [GCC 11 Release Notes](https://gcc.gnu.org/gcc-11/porting_to.html):
> Header dependency changes: Some C++ Standard Library headers have been changed to no longer include other headers that they do not need to depend on.

Closes #1005

---
Generated with [Claude Code](https://claude.com/claude-code)