### PR TITLE
contrib: Add litecoin-qt.desktop for Linux desktop integration

### DIFF
--- a/contrib/debian/litecoin-qt.desktop
+++ b/contrib/debian/litecoin-qt.desktop
@@ -1,0 +1,17 @@
+[Desktop Entry]
+Version=1.0
+Name=Litecoin Core
+Comment=Connect to the Litecoin P2P Network
+Comment[de]=Verbindung mit dem Litecoin Peer-to-Peer-Netzwerk herstellen
+Comment[es]=Conectar a la red P2P de Litecoin
+Comment[fr]=Se connecter au réseau pair à pair Litecoin
+GenericName=Cryptocurrency Wallet
+Exec=litecoin-qt %u
+Terminal=false
+Type=Application
+Icon=litecoin128
+MimeType=x-scheme-handler/litecoin;
+Categories=Office;Finance;Network;
+Keywords=litecoin;crypto;cryptocurrency;wallet;blockchain;
+StartupNotify=true
+StartupWMClass=Litecoin-qt


### PR DESCRIPTION
## Summary

Adds a freedesktop.org-compliant `.desktop` file for Linux desktop integration, as requested by the Debian maintainer in #1063.

## Features

The desktop file provides:
- **Application menu integration** - Litecoin Core appears in desktop environment menus
- **URI scheme handling** - Registers `litecoin:` protocol for web browser integration
- **Startup notification** - Provides feedback when launching
- **Proper categorization** - Listed under Office/Finance/Network categories
- **Multi-language comments** - German, Spanish, French translations
- **Search keywords** - Discoverable via `litecoin`, `crypto`, `wallet`, etc.

## File Location

`contrib/debian/litecoin-qt.desktop` - matching the location used by similar projects (Bitcoin, Dogecoin).

## Usage

Package maintainers can install to `/usr/share/applications/`:
```bash
install -Dm644 contrib/debian/litecoin-qt.desktop /usr/share/applications/litecoin-qt.desktop
```

## Note

The icon references `litecoin128` - package maintainers may need to install a corresponding icon to `/usr/share/pixmaps/` or use the existing `bitcoin128` with a symlink.

Relates to #1063

---
Generated with [Claude Code](https://claude.com/claude-code)