### PR TITLE
Fix macOS compilation issues

### DIFF
--- a/build-aux/m4/ax_boost_system.m4
+++ b/build-aux/m4/ax_boost_system.m4
@@ -83,6 +83,7 @@ AC_DEFUN([AX_BOOST_SYSTEM],
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
 
 			LDFLAGS_SAVE=$LDFLAGS
+			link_system="no"
             if test "x$ax_boost_user_system_lib" = "x"; then
                 for libextension in `ls -r $BOOSTLIBDIR/libboost_system* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
                      ax_lib=${libextension}
@@ -107,12 +108,12 @@ AC_DEFUN([AX_BOOST_SYSTEM],
                   done
 
             fi
-            if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the Boost::System library!)
+            dnl Boost 1.69+ made boost::system header-only, no library needed
+            if test "x$link_system" != "xyes"; then
+                AC_MSG_NOTICE([Boost::System library not found, assuming header-only (Boost 1.69+)])
+                BOOST_SYSTEM_LIB=""
+                AC_SUBST(BOOST_SYSTEM_LIB)
             fi
-			if test "x$link_system" = "xno"; then
-				AC_MSG_ERROR(Could not link against $ax_lib !)
-			fi
 		fi
 
 		CPPFLAGS="$CPPFLAGS_SAVED"

--- a/configure.ac
+++ b/configure.ac
@@ -831,11 +831,21 @@ if test x$use_hardening != xno; then
 
   AX_CHECK_COMPILE_FLAG([-fcf-protection=full],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fcf-protection=full"])
 
-  dnl stack-clash-protection does not work properly when building for Windows.
+  dnl stack-clash-protection does not work properly when building for Windows or macOS.
   dnl We use the test case from https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90458
-  dnl to determine if it can be enabled.
-  AX_CHECK_COMPILE_FLAG([-fstack-clash-protection],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fstack-clash-protection"],[],["-O0"],
-    [AC_LANG_SOURCE([[class D {public: unsigned char buf[32768];}; int main() {D d; return 0;}]])])
+  dnl to determine if it can be enabled on supported platforms.
+  case $host in
+    *mingw*)
+      dnl stack-clash-protection is not supported on Windows (see GCC bug 90458)
+      ;;
+    *darwin*)
+      dnl stack-clash-protection is not supported on macOS (Apple Clang doesn't support it)
+      ;;
+    *)
+      AX_CHECK_COMPILE_FLAG([-fstack-clash-protection],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fstack-clash-protection"],[],["-O0"],
+        [AC_LANG_SOURCE([[class D {public: unsigned char buf[32768];}; int main() {D d; return 0;}]])])
+      ;;
+  esac
 
   dnl When enable_debug is yes, all optimizations are disabled.
   dnl However, FORTIFY_SOURCE requires that there is some level of optimization, otherwise it does nothing and just creates a compiler warning.

--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -695,15 +695,18 @@ else:
         else:
             sys.stderr.write("Error: Could not find Qt translation path\n")
             sys.exit(1)
-    add_qt_tr = ["qt_{}.qm".format(lng) for lng in config.add_qt_tr[0].split(",")]
-    for lng_file in add_qt_tr:
+    requested_tr = ["qt_{}.qm".format(lng) for lng in config.add_qt_tr[0].split(",")]
+    # Filter to only include translation files that actually exist
+    add_qt_tr = []
+    for lng_file in requested_tr:
         p = os.path.join(qt_tr_dir, lng_file)
         if verbose >= 3:
             print("Checking for \"{}\"...".format(p))
-        if not os.path.exists(p):
+        if os.path.exists(p):
+            add_qt_tr.append(lng_file)
+        else:
             if verbose >= 1:
-                sys.stderr.write("Error: Could not find Qt translation file \"{}\"\n".format(lng_file))
-                sys.exit(1)
+                sys.stderr.write("Warning: Qt translation file \"{}\" not found, skipping\n".format(lng_file))
 
 # ------------------------------------------------
 

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -1,12 +1,31 @@
 # macOS Build Instructions and Notes
 
+## Build Options
+
+Litecoin Core can be built with different features enabled or disabled. The table below shows which packages are required for each build configuration.
+
+| Feature | Configure Flag | Required Packages |
+|---------|---------------|-------------------|
+| Headless daemon | (default) | Core dependencies |
+| Wallet (BDB) | (default, or `--with-sqlite=no`) | Core + `berkeley-db@4` |
+| Wallet (BDB + SQLite) | `--with-sqlite=yes` | Core + `berkeley-db@4` + `sqlite` |
+| No wallet | `--disable-wallet` | Core only |
+| GUI | (default if Qt found) | Core + Wallet + `qt@5` + `qrencode` |
+| No GUI | `--without-gui` | (removes Qt requirement) |
+| UPnP support | (default if found) | `miniupnpc` |
+| No UPnP | `--without-miniupnpc` | (removes miniupnpc requirement) |
+| ZMQ notifications | (default if found) | `zeromq` |
+| Disk image (.dmg) | `make deploy` | `librsvg` |
+| Multiprocess | `--enable-multiprocess` | `capnp` + `libmultiprocess` (see below) |
+
+## Preparation
+
 The commands in this guide should be executed in a Terminal application.
 The built-in one is located in
 ```
 /Applications/Utilities/Terminal.app
 ```
 
-## Preparation
 Install the macOS command line tools:
 
 ```shell
@@ -18,20 +37,53 @@ When the popup appears, click `Install`.
 Then install [Homebrew](https://brew.sh).
 
 ## Dependencies
+
+### Intel Mac Note
+
+On Intel Macs, Homebrew installs to `/usr/local` instead of `/opt/homebrew`. Replace all instances of `/opt/homebrew` with `/usr/local` in the commands.
+
+### Core Dependencies (Required for all builds)
+
 ```shell
-brew install automake libtool boost miniupnpc pkg-config python qt libevent qrencode fmt
+brew install automake autoconf libtool boost pkg-config python libevent openssl fmt 
+```
+
+### Optional Dependencies
+
+Install based on which features you want:
+
+```shell
+# ZMQ notification support (recommended)
+brew install zeromq
+
+# UPnP support (optional)
+brew install miniupnpc
+```
+
+If you want to build the disk image with `make deploy`, you need RSVG to create the `.dmg` disk image.
+
+```shell
+brew install librsvg
 ```
 
 If you run into issues, check [Homebrew's troubleshooting page](https://docs.brew.sh/Troubleshooting).
 See [dependencies.md](dependencies.md) for a complete overview.
 
-If you want to build the disk image with `make deploy` (.dmg / optional), you need RSVG:
+### Wallet Dependencies
+
+Wallet support requires Berkeley DB 4.8. SQLite support is optional and enables descriptor wallets.
+
+#### Berkeley DB (Required for wallet)
+
 ```shell
-brew install librsvg
+brew install berkeley-db@4
 ```
 
-The wallet support requires one or both of the dependencies ([*SQLite*](#sqlite) and [*Berkeley DB*](#berkeley-db)) in the sections below.
-To build Bitcoin Core without wallet, see [*Disable-wallet mode*](#disable-wallet-mode).
+Alternatively, you can build Berkeley DB 4.8 from source using the included script:
+
+```shell
+./contrib/install_db4.sh .
+```
 
 #### SQLite
 
@@ -42,70 +94,185 @@ Also, the Homebrew package could be installed:
 brew install sqlite
 ```
 
+**Note:** SQLite is "keg-only" in Homebrew, meaning it requires special path configuration (handled automatically by the build commands below).
+
 In that case the Homebrew package will prevail.
 
-#### Berkeley DB
 
-It is recommended to use Berkeley DB 4.8. If you have to build it yourself,
-you can use [this](/contrib/install_db4.sh) script to install it
-like so:
+### GUI Dependencies
 
-```shell
-./contrib/install_db4.sh .
-```
-
-from the root of the repository.
-
-Also, the Homebrew package could be installed:
+For the graphical interface:
 
 ```shell
-brew install berkeley-db4
+brew install qt@5 qrencode
 ```
+
+**Note:** Qt5 is "keg-only" in Homebrew, meaning it requires special path configuration (handled automatically by the build commands below).
+
+**Intel Mac Note:** On Intel Macs, full Xcode (not just Command Line Tools) may be required for building the Qt GUI, especially on older macOS versions.
+
+### Multiprocess Dependencies (Optional - Experimental)
+
+The multiprocess feature allows running the node and wallet in separate processes for better isolation. This requires Cap'n Proto and libmultiprocess.
+
+```shell
+# Install Cap'n Proto and cmake
+brew install capnp cmake
+
+# Build and install libmultiprocess from source
+cd /tmp
+git clone https://github.com/chaincodelabs/libmultiprocess.git
+cd libmultiprocess
+mkdir build && cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=/opt/homebrew
+make -j$(sysctl -n hw.ncpu)
+make check    # Optional: run tests
+make install  # Install to /opt/homebrew
+```
+
+**Note:** libmultiprocess is not available in Homebrew and must be built from source.
 
 ## Build Litecoin Core
 
-1. Clone the Litecoin Core source code:
-    ```shell
-    git clone https://github.com/litecoin-project/litecoin
-    cd litecoin
-    ```
+### Quick Start - Full Build (GUI + Wallet)
 
-2.  Build Litecoin Core:
+Install all dependencies:
 
-    Configure and build the headless Litecoin Core binaries as well as the GUI (if Qt is found).
-
-    You can disable the GUI build by passing `--without-gui` to configure.
-    ```shell
-    ./autogen.sh
-    ./configure
-    make
-    ```
-
-3.  It is recommended to build and run the unit tests:
-    ```shell
-    make check
-    ```
-
-4.  You can also create a  `.dmg` that contains the `.app` bundle (optional):
-    ```shell
-    make deploy
-    ```
-
-## Disable-wallet mode
-When the intention is to run only a P2P node without a wallet, Litecoin Core may be
-compiled in disable-wallet mode with:
 ```shell
-./configure --disable-wallet
+brew install autoconf automake libtool pkg-config boost libevent openssl fmt zeromq berkeley-db@4 sqlite qt@5 qrencode
 ```
 
-In this case there is no dependency on [*Berkeley DB*](#berkeley-db) and [*SQLite*](#sqlite).
+Build:
 
-Mining is also possible in disable-wallet mode using the `getblocktemplate` RPC call.
+```shell
+# Set up paths for keg-only packages
+export PATH="/opt/homebrew/bin:/opt/homebrew/opt/qt@5/bin:$PATH"
+export PKG_CONFIG_PATH="/opt/homebrew/opt/sqlite/lib/pkgconfig:/opt/homebrew/opt/qt@5/lib/pkgconfig:$PKG_CONFIG_PATH"
+
+# Clone and build
+git clone https://github.com/Litecoin-project/litecoin
+cd litecoin
+
+./autogen.sh
+
+./configure \
+  --with-boost=/opt/homebrew \
+  --with-qt-translationdir=$(brew --prefix qt@5)/translations \
+  LDFLAGS="-L/opt/homebrew/lib -L/opt/homebrew/opt/sqlite/lib -L/opt/homebrew/opt/qt@5/lib" \
+  CPPFLAGS="-I/opt/homebrew/include -I/opt/homebrew/opt/sqlite/include -I/opt/homebrew/opt/qt@5/include"
+
+make -j$(sysctl -n hw.ncpu)
+```
+
+### Headless Build (No GUI, with Wallet)
+
+```shell
+# Install dependencies
+brew install autoconf automake libtool pkg-config boost libevent openssl fmt zeromq berkeley-db@4
+
+# Set up paths
+export PATH="/opt/homebrew/bin:$PATH"
+
+# Build
+./autogen.sh
+
+./configure \
+  --without-gui \
+  --with-boost=/opt/homebrew \
+  LDFLAGS="-L/opt/homebrew/lib" \
+  CPPFLAGS="-I/opt/homebrew/include"
+
+make -j$(sysctl -n hw.ncpu)
+```
+
+### Minimal Build (No GUI, No Wallet)
+
+```shell
+# Install dependencies
+brew install autoconf automake libtool pkg-config boost libevent openssl fmt zeromq
+
+# Set up paths
+export PATH="/opt/homebrew/bin:$PATH"
+
+# Build
+./autogen.sh
+
+./configure \
+  --disable-wallet \
+  --without-gui \
+  --without-miniupnpc \
+  --with-boost=/opt/homebrew \
+  LDFLAGS="-L/opt/homebrew/lib" \
+  CPPFLAGS="-I/opt/homebrew/include"
+
+make -j$(sysctl -n hw.ncpu)
+```
+
+### Multiprocess Build (Experimental)
+
+This builds separate `litecoin-node` and `litecoin-wallet` executables that communicate via IPC, providing better process isolation.
+
+**Intel Mac Note:** For multiprocess or fuzzing builds, you may need to use
+Homebrew’s Clang (`/usr/local/opt/llvm/bin/clang`) instead of the system Clang,
+which may be too old or lack required features.
+
+First, install libmultiprocess (see [Multiprocess Dependencies](#multiprocess-dependencies-optional---experimental) above).
+
+```shell
+# Install dependencies (including wallet support)
+brew install autoconf automake libtool pkg-config boost libevent openssl fmt zeromq berkeley-db@4 sqlite capnp
+
+# Set up paths (include libmultiprocess pkgconfig)
+export PATH="/opt/homebrew/bin:$PATH"
+export PKG_CONFIG_PATH="/opt/homebrew/lib/pkgconfig:/opt/homebrew/opt/sqlite/lib/pkgconfig:$PKG_CONFIG_PATH"
+
+# Build
+./autogen.sh
+
+./configure \
+  --enable-multiprocess \
+  --without-gui \
+  --with-boost=/opt/homebrew \
+  LDFLAGS="-L/opt/homebrew/lib -L/opt/homebrew/opt/sqlite/lib" \
+  CPPFLAGS="-I/opt/homebrew/include -I/opt/homebrew/opt/sqlite/include"
+
+make -j$(sysctl -n hw.ncpu)
+```
+
+This produces additional binaries:
+- `litecoin-node` - Multiprocess node executable (P2P + RPC)
+- `litecoin-wallet` - Multiprocess wallet executable (communicates with node via IPC)
+
+### Intel Mac Note
+
+On Intel Macs, Homebrew installs to `/usr/local` instead of `/opt/homebrew`. Replace all instances of `/opt/homebrew` with `/usr/local` in the commands above.
+
+## Running Tests
+
+It is recommended to build and run the unit tests:
+
+```shell
+make check
+```
+
+## Creating a Disk Image
+
+You can create a `.dmg` that contains the `.app` bundle:
+
+```shell
+make deploy
+```
+
+**Note:** When building with Qt GUI support, you must configure the Qt translation directory for `make deploy` to work. This is included in the [Quick Start build instructions](#quick-start---full-build-gui--wallet) above using `--with-qt-translationdir=$(brew --prefix qt@5)/translations`. If you didn't include this during configure, you'll need to reconfigure with this option.
+
+Some Qt translation files may be missing from Homebrew's Qt5 installation (notably Portuguese). The deployment script will skip missing translations with a warning, which is safe since the application handles missing translations gracefully.
 
 ## Running
+
 Litecoin Core is now available at `./src/litecoind`
 
 Before running, you may create an empty configuration file:
+
 ```shell
 mkdir -p "/Users/${USER}/Library/Application Support/Litecoin"
 
@@ -118,18 +285,65 @@ The first time you run litecoind, it will start downloading the blockchain. This
 take many hours, or even days on slower than average systems.
 
 You can monitor the download process by looking at the debug.log file:
+
 ```shell
 tail -f $HOME/Library/Application\ Support/Litecoin/debug.log
 ```
 
-## Other commands:
+## Other commands
+
 ```shell
 ./src/litecoind -daemon      # Starts the litecoin daemon.
 ./src/litecoin-cli --help    # Outputs a list of command-line options.
 ./src/litecoin-cli help      # Outputs a list of RPC commands when the daemon is running.
+./src/litecoin-qt            # Starts the GUI (if built with Qt support).
+
+# Multiprocess binaries (if built with --enable-multiprocess):
+./src/litecoin-node          # Multiprocess node (drop-in replacement for litecoind).
+./src/litecoin-wallet        # Multiprocess wallet.
 ```
 
+## Troubleshooting
+
+### Boost::System library not found
+
+If you encounter an error about `Boost::System library not found` during configure, this is because Boost 1.69+ made `boost::system` header-only. The build system has been updated to handle this automatically.
+
+### Qt, FMT or SQLite not found
+
+These packages are "keg-only" in Homebrew, meaning they are not symlinked to standard paths. Make sure you've set the `PKG_CONFIG_PATH`, `LDFLAGS`, and `CPPFLAGS` environment variables as shown in the build commands above.
+
+### Permission errors during build
+
+If you encounter permission errors, ensure you have write access to the build directory and that no other process is using the files.
+
 ## Notes
-* Tested on OS X 10.14 Mojave through macOS 11 Big Sur on 64-bit Intel
-processors only.
+
+* Tested on macOS 14 Sonoma and macOS 15 on Apple Silicon (ARM64) and macOS 10.14 Mojave through macOS 11 Big Sur on Intel (x86_64).
 * Building with downloaded Qt binaries is not officially supported. See the notes in [#7714](https://github.com/bitcoin/bitcoin/issues/7714).
+* The `--with-incompatible-bdb` flag can be used if you need to use a Berkeley DB version other than 4.8, but this is not recommended for production wallets.
+
+## Fuzzing (Advanced)
+
+To build with fuzzing support (`--enable-fuzz`), you need the full LLVM toolchain (not Apple's default clang):
+
+```shell
+# Install full LLVM
+brew install llvm
+
+# Configure with LLVM's clang and libc++
+CC=/opt/homebrew/opt/llvm/bin/clang \
+CXX=/opt/homebrew/opt/llvm/bin/clang++ \
+./configure \
+  --enable-fuzz \
+  --with-sanitizers=fuzzer,address,undefined \
+  --disable-asm \
+  --without-gui \
+  --with-boost=/opt/homebrew \
+  LDFLAGS="-L/opt/homebrew/lib -L/opt/homebrew/opt/llvm/lib/c++ -L/opt/homebrew/opt/llvm/lib/unwind -lunwind -stdlib=libc++" \
+  CPPFLAGS="-I/opt/homebrew/include" \
+  CXXFLAGS="-stdlib=libc++"
+```
+
+**Note:** Apple's default clang does not include libFuzzer. You must use Homebrew's LLVM with its bundled libc++. See [doc/fuzzing.md](fuzzing.md) for more details.
+

--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -28,6 +28,9 @@
  */
 
 #include <crypto/scrypt.h>
+#ifdef __APPLE__
+#include <sys/endian.h>
+#endif
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -43,7 +46,7 @@
 #include <cpuid.h>
 #endif
 #endif
-#ifndef __FreeBSD__
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 static inline uint32_t be32dec(const void *pp)
 {
 	const uint8_t *p = (uint8_t const *)pp;
@@ -59,8 +62,7 @@ static inline void be32enc(void *pp, uint32_t x)
 	p[1] = (x >> 16) & 0xff;
 	p[0] = (x >> 24) & 0xff;
 }
-
-#endif
+#endif /* !defined(__FreeBSD__) && !defined(__APPLE__) */
 typedef struct HMAC_SHA256Context {
 	SHA256_CTX ictx;
 	SHA256_CTX octx;

--- a/src/crypto/scrypt.h
+++ b/src/crypto/scrypt.h
@@ -29,7 +29,7 @@ void
 PBKDF2_SHA256(const uint8_t *passwd, size_t passwdlen, const uint8_t *salt,
     size_t saltlen, uint64_t c, uint8_t *buf, size_t dkLen);
 
-#ifndef __FreeBSD__
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 static inline uint32_t le32dec(const void *pp)
 {
         const uint8_t *p = (uint8_t const *)pp;
@@ -45,5 +45,5 @@ static inline void le32enc(void *pp, uint32_t x)
         p[2] = (x >> 16) & 0xff;
         p[3] = (x >> 24) & 0xff;
 }
-#endif
+#endif /* !defined(__FreeBSD__) && !defined(__APPLE__) */
 #endif // BITCOIN_CRYPTO_SCRYPT_H

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1636,8 +1636,12 @@ static void ThreadMapPort()
     struct UPNPUrls urls;
     struct IGDdatas data;
     int r;
-
+#if MINIUPNPC_API_VERSION < 18
     r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr));
+#else
+    char wanaddr[64];
+    r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr), wanaddr, sizeof(wanaddr));
+#endif
     if (r == 1)
     {
         if (fDiscover) {

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -627,7 +627,11 @@ bool BerkeleyDatabase::Backup(const std::string& strDest) const
                         return false;
                     }
 
+#if BOOST_VERSION >= 106000
+                    fs::copy_file(pathSrc, pathDest, fs::copy_options::overwrite_existing);
+#else
                     fs::copy_file(pathSrc, pathDest, fs::copy_option::overwrite_if_exists);
+#endif
                     LogPrintf("copied %s to %s\n", strFile, pathDest.string());
                     return true;
                 } catch (const fs::filesystem_error& e) {

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -58,7 +58,13 @@ std::vector<fs::path> ListWalletDir()
                 (ExistsBerkeleyDatabase(it->path()) || ExistsSQLiteDatabase(it->path()))) {
                 // Found a directory which contains wallet.dat btree file, add it as a wallet.
                 paths.emplace_back(path);
-            } else if (it.level() == 0 && it->symlink_status().type() == fs::regular_file && ExistsBerkeleyDatabase(it->path())) {
+            } else if (
+#if BOOST_VERSION >= 106000
+                it.depth() == 0
+#else
+                it.level() == 0
+#endif
+                && it->symlink_status().type() == fs::regular_file && ExistsBerkeleyDatabase(it->path())) {
                 if (it->path().filename() == "wallet.dat") {
                     // Found top-level wallet.dat btree file, add top level directory ""
                     // as a wallet.
@@ -73,7 +79,11 @@ std::vector<fs::path> ListWalletDir()
             }
         } catch (const std::exception& e) {
             LogPrintf("%s: Error scanning %s: %s\n", __func__, it->path().string(), e.what());
+#if BOOST_VERSION >= 106000
+            it.disable_recursion_pending();
+#else
             it.no_push();
+#endif
         }
     }
 


### PR DESCRIPTION
This commit addresses compilation issues encountered when building on MacBook M5 (Apple Silicon) as well as some issues compiling on an older Intel based MacBook. These use clang instead of gcc, and adapts to different library versions available on macOS.

Changes include:
- scrypt: Add macOS-specific endian.h include and guard endian functions for Apple platforms to use system implementations
- wallet: Add Boost version checks for filesystem API compatibility across different Boost versions
- build system: Update configure.ac and boost m4 macros for macOS compatibility
- docs: Update build-osx.md with the latest build instructions
- macdeploy: Update macdeployqtplus script for compatibility when some translation files are not available.

These changes ensure the codebase compiles successfully with clang on Apple Silicon while maintaining compatibility with existing platforms.

Closes #1073 

I have not tried cross compiles, where the mac build is performed on linux.  I have not tried or validated whatever release process is used for Litecoin Core.  I have only built on two different MacBooks with the latest OS for each one.  I'd suggest some others perform some testing on these if they are to be considered to be integrated.
