### PR TITLE
Fixes litecoin#1079 by preventing notifications

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -487,7 +487,7 @@ void BitcoinGUI::createMenuBar()
     connect(minimize_action, &QAction::triggered, [] {
         QApplication::activeWindow()->showMinimized();
     });
-    connect(qApp, &QApplication::focusWindowChanged, [minimize_action] (QWindow* window) {
+    connect(qApp, &QApplication::focusWindowChanged, this, [minimize_action] (QWindow* window) {
         minimize_action->setEnabled(window != nullptr && (window->flags() & Qt::Dialog) != Qt::Dialog && window->windowState() != Qt::WindowMinimized);
     });
 
@@ -502,7 +502,7 @@ void BitcoinGUI::createMenuBar()
         }
     });
 
-    connect(qApp, &QApplication::focusWindowChanged, [zoom_action] (QWindow* window) {
+    connect(qApp, &QApplication::focusWindowChanged, this, [zoom_action] (QWindow* window) {
         zoom_action->setEnabled(window != nullptr);
     });
 #endif


### PR DESCRIPTION
MacOS 13 sends a window focus change notification after the main window has been destroyed but before the QTApplication has been destroyed. This results in the menu bar receiving a notification despite it no longer existing. The solution is to pass the main window as context when subscribing to the notifications. Qt automatically unsubscribes to notifications if the sender OR context is destroyed.

Fixes #1079 

This was a cherry-pick of 8a5014cd8a05b3ab86ae34a47653a82ce11bdf17 from the bitcoin-core GUI repo.