### PR TITLE
Add signet chain support

### DIFF
--- a/doc/release-notes/signet.md
+++ b/doc/release-notes/signet.md
@@ -1,0 +1,6 @@
+Signet
+------
+
+Litecoin Core now supports signet via `-signet`. The default signet
+challenge is `OP_TRUE` for local developer use. Custom signet networks
+can be selected with `-signetchallenge=<hex>`.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -64,6 +64,48 @@ static std::vector<uint256> GetFrozenMWEBOutputIDs()
     };
 }
 
+static CBlock CreateSignetGenesisBlock()
+{
+    const char* pszTimestamp = "Litecoin Signet 27/Apr/2026 - A predictable test network for Litecoin";
+    const CScript genesisOutputScript = CScript() << ParseHex("040184710fa689ad5023690c80f3a49c8f13f8d45b8c857fbcbc8bc4a8e4d3eb4b10f4d4604fa08dce601aaf0f470216fe1b51850b4acf21b179c45070ac7b03a9") << OP_CHECKSIG;
+    return CreateGenesisBlock(pszTimestamp, genesisOutputScript, 1777248000, 1603, 0x1f00ffff, 1, 50 * COIN);
+}
+
+static const std::vector<uint8_t>& DefaultSignetChallenge()
+{
+    static const std::vector<uint8_t> challenge = ParseHex("51");
+    return challenge;
+}
+
+static std::vector<uint8_t> GetSignetChallenge(const ArgsManager& args)
+{
+    if (!args.IsArgSet("-signetchallenge")) return DefaultSignetChallenge();
+
+    const auto challenges = args.GetArgs("-signetchallenge");
+    if (challenges.size() != 1) {
+        throw std::runtime_error("-signetchallenge cannot be multiple values.");
+    }
+
+    const std::string& challenge = challenges[0];
+    if (!IsHex(challenge)) {
+        throw std::runtime_error(strprintf("Invalid -signetchallenge '%s'. Must be hex.", challenge));
+    }
+
+    std::vector<uint8_t> parsed_challenge = ParseHex(challenge);
+    if (parsed_challenge.empty()) {
+        throw std::runtime_error("Invalid -signetchallenge. Challenge may not be empty.");
+    }
+
+    return parsed_challenge;
+}
+
+static uint256 DeriveSignetMessageStartHash(const std::vector<uint8_t>& challenge)
+{
+    CHashWriter h(SER_DISK, 0);
+    h << challenge;
+    return h.GetHash();
+}
+
 /**
  * Main network
  */
@@ -283,6 +325,90 @@ public:
     }
 };
 
+class CSigNetParams : public CChainParams {
+public:
+    explicit CSigNetParams(const ArgsManager& args) {
+        strNetworkID = CBaseChainParams::SIGNET;
+        consensus.signet_blocks = true;
+        consensus.signet_challenge = GetSignetChallenge(args);
+        consensus.nSubsidyHalvingInterval = 840000;
+        consensus.BIP16Height = 1;
+        consensus.BIP34Height = 1;
+        consensus.BIP34Hash = uint256();
+        consensus.BIP65Height = 1;
+        consensus.BIP66Height = 1;
+        consensus.CSVHeight = 1;
+        consensus.SegwitHeight = 1;
+        consensus.MinBIP9WarningHeight = 0;
+        consensus.powLimit = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.nPowTargetTimespan = 3.5 * 24 * 60 * 60;
+        consensus.nPowTargetSpacing = 2.5 * 60;
+        consensus.fPowAllowMinDifficultyBlocks = false;
+        consensus.fPowNoRetargeting = false;
+        consensus.nRuleChangeActivationThreshold = 1512;
+        consensus.nMinerConfirmationWindow = 2016;
+
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 2;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+
+        consensus.vDeployments[Consensus::DEPLOYMENT_MWEB].bit = 4;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MWEB].nStartHeight = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MWEB].nTimeoutHeight = Consensus::BIP9Deployment::NO_TIMEOUT;
+
+        consensus.nMinimumChainWork = uint256{};
+        consensus.defaultAssumeValid = uint256{};
+
+        const uint256 signet_message_start = DeriveSignetMessageStartHash(consensus.signet_challenge);
+        for (size_t i = 0; i < CMessageHeader::MESSAGE_START_SIZE; ++i) {
+            pchMessageStart[i] = signet_message_start.begin()[i];
+        }
+        nDefaultPort = 39335;
+        nPruneAfterHeight = 1000;
+        m_assumed_blockchain_size = 0;
+        m_assumed_chain_state_size = 0;
+
+        genesis = CreateSignetGenesisBlock();
+        consensus.hashGenesisBlock = genesis.GetHash();
+        assert(consensus.hashGenesisBlock == uint256S("0x41b5ad040995f9deab05f0a61c0e992164f6e689a8ea32a4b7450bd313210a43"));
+        assert(genesis.hashMerkleRoot == uint256S("0x99d360668018416a453d5c2bba870f1846a4f5969b7e80ecaf3aa444a825d8dd"));
+
+        vFixedSeeds.clear();
+        vSeeds.clear();
+
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);
+        base58Prefixes[SCRIPT_ADDRESS2] = std::vector<unsigned char>(1,58);
+        base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
+        base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x35, 0x87, 0xCF};
+        base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
+
+        bech32_hrp = "tltc";
+        mweb_hrp = "tmweb";
+
+        fDefaultConsistencyChecks = false;
+        fRequireStandard = false;
+        m_is_test_chain = true;
+        m_is_mockable_chain = false;
+
+        checkpointData = {
+            {
+                {0, uint256S("41b5ad040995f9deab05f0a61c0e992164f6e689a8ea32a4b7450bd313210a43")},
+            }
+        };
+
+        chainTxData = ChainTxData{
+            0,
+            0,
+            0,
+        };
+    }
+};
+
 /**
  * Regression test
  */
@@ -448,7 +574,7 @@ std::unique_ptr<const CChainParams> CreateChainParams(const ArgsManager& args, c
     } else if (chain == CBaseChainParams::TESTNET) {
         return std::unique_ptr<CChainParams>(new CTestNetParams());
     } else if (chain == CBaseChainParams::SIGNET) {
-        return std::unique_ptr<CChainParams>(new CTestNetParams()); // TODO: Support SigNet
+        return std::unique_ptr<CChainParams>(new CSigNetParams(args));
     } else if (chain == CBaseChainParams::REGTEST) {
         return std::unique_ptr<CChainParams>(new CRegTestParams(args));
     }

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -25,8 +25,8 @@ void SetupChainParamsBaseOptions(ArgsManager& argsman)
     argsman.AddArg("-testnet", "Use the test chain. Equivalent to -chain=test.", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-vbparams=deployment:start:end[:start_height:end_height]", "Use given start/end times and start/end block heights for specified version bits deployment (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-signet", "Use the signet chain. Equivalent to -chain=signet. Note that the network is defined by the -signetchallenge parameter", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
-    argsman.AddArg("-signetchallenge", "Blocks must satisfy the given script to be considered valid (only for signet networks; defaults to the global default signet test network challenge)", ArgsManager::ALLOW_STRING, OptionsCategory::CHAINPARAMS);
-    argsman.AddArg("-signetseednode", "Specify a seed node for the signet network, in the hostname[:port] format, e.g. sig.net:1234 (may be used multiple times to specify multiple seed nodes; defaults to the global default signet test network seed node(s))", ArgsManager::ALLOW_STRING, OptionsCategory::CHAINPARAMS);
+    argsman.AddArg("-signetchallenge", "Blocks must satisfy the given script to be considered valid (only for signet networks; defaults to OP_TRUE)", ArgsManager::ALLOW_STRING, OptionsCategory::CHAINPARAMS);
+    argsman.AddArg("-signetseednode", "Specify a seed node for the signet network, in the hostname[:port] format, e.g. sig.net:1234 (may be used multiple times to specify multiple seed nodes)", ArgsManager::ALLOW_STRING, OptionsCategory::CHAINPARAMS);
 }
 
 static std::unique_ptr<CBaseChainParams> globalChainBaseParams;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2017,6 +2017,10 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
     }
 
     connOptions.vSeedNodes = args.GetArgs("-seednode");
+    if (args.GetChainName() == CBaseChainParams::SIGNET) {
+        const auto signet_seed_nodes = args.GetArgs("-signetseednode");
+        connOptions.vSeedNodes.insert(connOptions.vSeedNodes.end(), signet_seed_nodes.begin(), signet_seed_nodes.end());
+    }
 
     // Initiate outbound connections unless connect=0
     connOptions.m_use_addrman_outgoing = !args.IsArgSet("-connect");

--- a/test/functional/feature_signet.py
+++ b/test/functional/feature_signet.py
@@ -2,25 +2,18 @@
 # Copyright (c) 2019-2020 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test basic signet functionality"""
+"""Test basic signet functionality for Litecoin's scrypt-based signet."""
 
 from decimal import Decimal
 
-from test_framework.test_framework import BitcoinTestFramework, SkipTest
+from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
-signet_blocks = [
-    '00000020f61eee3b63a380a477a063af32b2bbc97c9ff9f01f2c4225e973988108000000f575c83235984e7dc4afc1f30944c170462e84437ab6f2d52e16878a79e4678bd1914d5fae77031eccf4070001010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff025151feffffff0200f2052a010000001600149243f727dd5343293eb83174324019ec16c2630f0000000000000000776a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf94c4fecc7daa2490047304402205e423a8754336ca99dbe16509b877ef1bf98d008836c725005b3c787c41ebe46022047246e4467ad7cc7f1ad98662afcaf14c115e0095a227c7b05c5182591c23e7e01000120000000000000000000000000000000000000000000000000000000000000000000000000',
-    '00000020533b53ded9bff4adc94101d32400a144c54edc5ed492a3b26c63b2d686000000b38fef50592017cfafbcab88eb3d9cf50b2c801711cad8299495d26df5e54812e7914d5fae77031ecfdd0b0001010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff025251feffffff0200f2052a01000000160014fd09839740f0e0b4fc6d5e2527e4022aa9b89dfa0000000000000000776a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf94c4fecc7daa24900473044022031d64a1692cdad1fc0ced69838169fe19ae01be524d831b95fcf5ea4e6541c3c02204f9dea0801df8b4d0cd0857c62ab35c6c25cc47c930630dc7fe723531daa3e9b01000120000000000000000000000000000000000000000000000000000000000000000000000000',
-    '000000202960f3752f0bfa8858a3e333294aedc7808025e868c9dc03e71d88bb320000007765fcd3d5b4966beb338bba2675dc2cf2ad28d4ad1d83bdb6f286e7e27ac1f807924d5fae77031e81d60b0001010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff025351feffffff0200f2052a010000001600141e5fb426042692ae0e87c070e78c39307a5661c20000000000000000776a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf94c4fecc7daa2490047304402205de93694763a42954865bcf1540cb82958bc62d0ec4eee02070fb7937cd037f4022067f333753bce47b10bc25eb6e1f311482e994c862a7e0b2d41ab1c8679fd1b1101000120000000000000000000000000000000000000000000000000000000000000000000000000',
-    '00000020b06443a13ae1d3d50faef5ecad38c6818194dc46abca3e972e2aacdae800000069a5829097e80fee00ac49a56ea9f82d741a6af84d32b3bc455cf31871e2a8ac27924d5fae77031e9c91050001010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff025451feffffff0200f2052a0100000016001430db2f8225dcf7751361ab38735de08190318cb70000000000000000776a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf94c4fecc7daa2490047304402200936f5f9872f6df5dd242026ad52241a68423f7f682e79169a8d85a374eab9b802202cd2979c48b321b3453e65e8f92460db3fca93cbea8539b450c959f4fbe630c601000120000000000000000000000000000000000000000000000000000000000000000000000000',
-    '000000207ed403758a4f228a1939418a155e2ebd4ae6b26e5ffd0ae433123f7694010000542e80b609c5bc58af5bdf492e26d4f60cd43a3966c2e063c50444c29b3757a636924d5fae77031ee8601d0001010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff025551feffffff0200f2052a01000000160014edc207e014df34fa3885dff97d1129d356e1186a0000000000000000776a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf94c4fecc7daa24900473044022021a3656609f85a66a2c5672ed9322c2158d57251040d2716ed202a1fe14f0c12022057d68bc6611f7a9424a7e00bbf3e27e6ae6b096f60bac624a094bc97a59aa1ff01000120000000000000000000000000000000000000000000000000000000000000000000000000',
-    '000000205bea0a88d1422c3df08d766ad72df95084d0700e6f873b75dd4e986c7703000002b57516d33ed60c2bdd9f93d6d5614083324c837e68e5ba6e04287a7285633585924d5fae77031ed171960001010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff025651feffffff0200f2052a010000001600143ae612599cf96f2442ce572633e0251116eaa52f0000000000000000776a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf94c4fecc7daa24900473044022059a7c54de76bfdbb1dd44c78ea2dbd2bb4e97f4abad38965f41e76433e56423c022054bf17f04fe17415c0141f60eebd2b839200f574d8ad8d55a0917b92b0eb913401000120000000000000000000000000000000000000000000000000000000000000000000000000',
-    '00000020daf3b60d374b19476461f97540498dcfa2eb7016238ec6b1d022f82fb60100007a7ae65b53cb988c2ec92d2384996713821d5645ffe61c9acea60da75cd5edfa1a944d5fae77031e9dbb050001010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff025751feffffff0200f2052a01000000160014ef2dceae02e35f8137de76768ae3345d99ca68860000000000000000776a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf94c4fecc7daa2490047304402202b3f946d6447f9bf17d00f3696cede7ee70b785495e5498274ee682a493befd5022045fc0bcf9332243168b5d35507175f9f374a8eba2336873885d12aada67ea5f601000120000000000000000000000000000000000000000000000000000000000000000000000000',
-    '00000020457cc5f3c2e1a5655bc20e20e48d33e1b7ea68786c614032b5c518f0b6000000541f36942d82c6e7248275ff15c8933487fbe1819c67a9ecc0f4b70bb7e6cf672a944d5fae77031e8f39860001010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff025851feffffff0200f2052a0100000016001472a27906947c06d034b38ba2fa13c6391a4832790000000000000000776a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf94c4fecc7daa2490047304402202d62805ce60cbd60591f97f949b5ea5bd7e2307bcde343e6ea8394da92758e72022053a25370b0aa20da100189b7899a8f8675a0fdc60e38ece6b8a4f98edd94569e01000120000000000000000000000000000000000000000000000000000000000000000000000000',
-    '00000020a2eb61eb4f3831baa3a3363e1b42db4462663f756f07423e81ed30322102000077224de7dea0f8d0ec22b1d2e2e255f0a987b96fe7200e1a2e6373f48a2f5b7894954d5fae77031e36867e0001010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff025951feffffff0200f2052a01000000160014aa0ad9f26801258382e0734dceec03a4a75f60240000000000000000776a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf94c4fecc7daa2490047304402206fa0d59990eed369bd7375767c9a6c9369fae209152b8674e520da270605528c0220749eed3b12dbe3f583f505d21803e4aef59c8e24c5831951eafa4f15a8f92c4e01000120000000000000000000000000000000000000000000000000000000000000000000000000',
-    '00000020a868e8514be5e46dabd6a122132f423f36a43b716a40c394e2a8d063e1010000f4c6c717e99d800c699c25a2006a75a0c5c09f432a936f385e6fce139cdbd1a5e9964d5fae77031e7d026e0001010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff025a51feffffff0200f2052a01000000160014aaa671c82b138e3b8f510cd801e5f2bd0aa305940000000000000000776a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf94c4fecc7daa24900473044022042309f4c3c7a1a2ac8c24f890f962df1c0086cec10be0868087cfc427520cb2702201dafee8911c269b7e786e242045bb57cef3f5b0f177010c6159abae42f646cc501000120000000000000000000000000000000000000000000000000000000000000000000000000',
-]
+CUSTOM_CHALLENGE = "512103ad5e0edad18cb1f0fc0d28a3d4f1f3e445640337489abb10404f2d1e086be430210359ef5021964fe22d6f8e05b2463c9540ce96883fe3b278760f048f5189f2e6c452ae"
+CUSTOM_CHALLENGE_2_OF_2 = "522103ad5e0edad18cb1f0fc0d28a3d4f1f3e445640337489abb10404f2d1e086be430210359ef5021964fe22d6f8e05b2463c9540ce96883fe3b278760f048f5189f2e6c452ae"
+DEFAULT_MAGIC = "54d26fbd"
+CUSTOM_MAGIC = "0a03cf40"
+CUSTOM_2_OF_2_MAGIC = "7f2df3ca"
 
 
 class SignetBasicTest(BitcoinTestFramework):
@@ -28,50 +21,55 @@ class SignetBasicTest(BitcoinTestFramework):
         self.chain = "signet"
         self.num_nodes = 6
         self.setup_clean_chain = True
-        shared_args1 = ["-signetchallenge=51"]  # OP_TRUE
-        shared_args2 = []  # default challenge
-        # we use the exact same challenge except we do it as a 2-of-2, which means it should fail
-        shared_args3 = ["-signetchallenge=522103ad5e0edad18cb1f0fc0d28a3d4f1f3e445640337489abb10404f2d1e086be430210359ef5021964fe22d6f8e05b2463c9540ce96883fe3b278760f048f5189f2e6c452ae"]
-
+        self.rpc_timeout = 240
         self.extra_args = [
-            shared_args1, shared_args1,
-            shared_args2, shared_args2,
-            shared_args3, shared_args3,
+            [],
+            [],
+            [f"-signetchallenge={CUSTOM_CHALLENGE}"],
+            [f"-signetchallenge={CUSTOM_CHALLENGE}"],
+            [f"-signetchallenge={CUSTOM_CHALLENGE_2_OF_2}"],
+            [f"-signetchallenge={CUSTOM_CHALLENGE_2_OF_2}"],
         ]
 
-    def run_test(self):
-        if True:
-            raise SkipTest("Signet not supported")
+    def setup_network(self):
+        self.setup_nodes()
+        self.connect_nodes(1, 0)
+        self.connect_nodes(3, 2)
+        self.connect_nodes(5, 4)
 
+    def assert_signet_magic(self, node, expected_magic):
+        with self.nodes[node].assert_debug_log([f"Signet derived magic (message start): {expected_magic}"]):
+            self.restart_node(node)
+
+    def run_test(self):
         self.log.info("basic tests using OP_TRUE challenge")
 
-        self.log.info('getmininginfo')
+        self.log.info("getmininginfo")
         mining_info = self.nodes[0].getmininginfo()
-        assert_equal(mining_info['blocks'], 0)
-        assert_equal(mining_info['chain'], 'signet')
-        assert 'currentblocktx' not in mining_info
-        assert 'currentblockweight' not in mining_info
-        assert_equal(mining_info['networkhashps'], Decimal('0'))
-        assert_equal(mining_info['pooledtx'], 0)
+        assert_equal(mining_info["blocks"], 0)
+        assert_equal(mining_info["chain"], "signet")
+        assert "currentblocktx" not in mining_info
+        assert "currentblockweight" not in mining_info
+        assert_equal(mining_info["networkhashps"], Decimal("0"))
+        assert_equal(mining_info["pooledtx"], 0)
 
-        self.nodes[0].generate(1)
+        self.log.info("mine a block on the OP_TRUE signet and sync the matching peer")
+        self.nodes[0].generate(1, maxtries=10000000)
+        self.sync_blocks([self.nodes[0], self.nodes[1]])
+        assert_equal(self.nodes[1].getblockcount(), 1)
 
-        self.log.info("pregenerated signet blocks check")
+        self.log.info("blocks from one signet challenge are rejected by other signets")
+        block = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 0)
+        assert_equal(self.nodes[2].submitblock(block), "bad-signet-blksig")
+        assert_equal(self.nodes[2].getblockcount(), 0)
+        assert_equal(self.nodes[4].submitblock(block), "bad-signet-blksig")
+        assert_equal(self.nodes[4].getblockcount(), 0)
 
-        height = 0
-        for block in signet_blocks:
-            assert_equal(self.nodes[2].submitblock(block), None)
-            height += 1
-            assert_equal(self.nodes[2].getblockcount(), height)
-
-        self.log.info("pregenerated signet blocks check (incompatible solution)")
-
-        assert_equal(self.nodes[4].submitblock(signet_blocks[0]), 'bad-signet-blksig')
-
-        self.log.info("test that signet logs the network magic on node start")
-        with self.nodes[0].assert_debug_log(["Signet derived magic (message start)"]):
-            self.restart_node(0)
+        self.log.info("test that signet logs the derived network magic on node start")
+        self.assert_signet_magic(0, DEFAULT_MAGIC)
+        self.assert_signet_magic(2, CUSTOM_MAGIC)
+        self.assert_signet_magic(4, CUSTOM_2_OF_2_MAGIC)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     SignetBasicTest().main()


### PR DESCRIPTION
This adds Litecoin signet chain parameters and enables signet as a distinct chain instead of aliasing it to testnet.

The default signet challenge is OP_TRUE for local developer use, so `litecoind -signet` works out of the box. Custom signet networks can still be selected with `-signetchallenge=<hex>`, and message-start bytes are derived from the active challenge so different signet challenges are isolated at the P2P layer.

Tested with:
- `src/test/test_litecoin --run_test=pow_tests --catch_system_errors=no`
- `src/test/test_litecoin --catch_system_errors=no`
- `test/functional/test_runner.py feature_signet.py`