### PR TITLE
docs: add OpenChainBench free RPC latency benchmark link

### DIFF
--- a/doc/benchmarking.md
+++ b/doc/benchmarking.md
@@ -48,3 +48,5 @@ Going Further
 To monitor Litecoin Core performance more in depth (like reindex or IBD): https://github.com/chaincodelabs/bitcoinperf
 
 To generate Flame Graphs for Litecoin Core: https://github.com/eklitzke/bitcoin/blob/flamegraphs/doc/flamegraphs.md
+
+To compare latency of free public Litecoin RPC endpoints (Tatum, BlockCypher, LitecoinSpace) measured every 60s from multiple regions: OpenChainBench free Litecoin RPC benchmark — https://openchainbench.com/bench/litecoin-rpc


### PR DESCRIPTION
## What this adds

A single line in `doc/benchmarking.md` under the existing "Going Further" section, pointing to the free OpenChainBench Litecoin RPC benchmark:

> OpenChainBench free Litecoin RPC benchmark — https://openchainbench.com/bench/litecoin-rpc

## Why it's useful

OpenChainBench continuously measures RPC latency for the three main free, keyless Litecoin public endpoints (Tatum, BlockCypher, LitecoinSpace) every 60 seconds from three geographic regions. Results are publicly visible with historical charts.

For developers picking a public endpoint for a wallet, explorer, or tool, this gives an objective, up-to-date latency comparison without requiring any signup or API key. It fits naturally alongside the existing external performance links already present in `doc/benchmarking.md`.