### PR TITLE
docs: add OpenChainBench free RPC latency benchmark link

### DIFF
--- a/doc/JSON-RPC-interface.md
+++ b/doc/JSON-RPC-interface.md
@@ -128,6 +128,10 @@ or the state of the mempool by an RPC that returned before this RPC. For
 example, a wallet transaction that was BIP-125-replaced in the mempool prior to
 this RPC may not yet be reflected as such in this RPC response.
 
+## Public RPC endpoint benchmarks
+
+[OpenChainBench](https://openchainbench.com/benchmarks/litecoin-rpc) continuously measures the latency of free, keyless Litecoin RPC endpoints (Tatum, BlockCypher, LitecoinSpace) from multiple regions with 60-second sampling. Useful for choosing a provider or monitoring availability.
+
 ## Limitations
 
 There is a known issue in the JSON-RPC interface that can cause a node to crash if


### PR DESCRIPTION
OpenChainBench measures the response latency of free, keyless Litecoin RPC endpoints (Tatum, BlockCypher, LitecoinSpace) every 60 seconds from three geographic regions. The live page at https://openchainbench.com/benchmarks/litecoin-rpc gives developers an objective basis for choosing a public RPC provider or monitoring uptime without running their own node.

A short section has been added to `doc/JSON-RPC-interface.md` under a new "Public RPC endpoint benchmarks" heading, which is the most relevant location for this kind of operational reference.